### PR TITLE
Add ctime options to CLI

### DIFF
--- a/cli/src/command/append.rs
+++ b/cli/src/command/append.rs
@@ -107,6 +107,13 @@ pub(crate) struct AppendCommand {
         help = "This is equivalent to --uname \"\" --gname \"\". It causes user and group names to not be stored in the archive"
     )]
     pub(crate) numeric_owner: bool,
+    #[arg(long, help = "Overrides the creation time read from disk")]
+    ctime: Option<DateTime>,
+    #[arg(
+        long,
+        help = "Clamp the creation time of the entries to the specified time by --ctime"
+    )]
+    clamp_ctime: bool,
     #[arg(long, help = "Overrides the modification time read from disk")]
     mtime: Option<DateTime>,
     #[arg(
@@ -198,7 +205,9 @@ fn append_to_archive(args: AppendCommand) -> io::Result<()> {
         args.numeric_owner,
     );
     let time_options = TimeOptions {
+        ctime: args.ctime.map(|it| it.to_system_time()),
         mtime: args.mtime.map(|it| it.to_system_time()),
+        clamp_ctime: args.clamp_ctime,
         clamp_mtime: args.clamp_mtime,
     };
     let create_options = CreateOptions {

--- a/cli/src/command/stdio.rs
+++ b/cli/src/command/stdio.rs
@@ -41,6 +41,7 @@ use std::{fs, io, path::PathBuf, time::SystemTime};
     group(ArgGroup::new("group-flag").args(["numeric_owner", "gname"])),
     group(ArgGroup::new("recursive-flag").args(["recursive", "no_recursive"])),
     group(ArgGroup::new("action-flags").args(["create", "extract", "list", "append"])),
+    group(ArgGroup::new("ctime-flag").args(["clamp_ctime"]).requires("ctime")),
     group(ArgGroup::new("mtime-flag").args(["clamp_mtime"]).requires("mtime")),
 )]
 #[cfg_attr(windows, command(
@@ -152,6 +153,13 @@ pub(crate) struct StdioCommand {
         help = "This is equivalent to --uname \"\" --gname \"\". On create, it causes user and group names to not be stored in the archive. On extract, it causes user and group names in the archive to be ignored in favor of the numeric user and group ids."
     )]
     pub(crate) numeric_owner: bool,
+    #[arg(long, help = "Overrides the creation time")]
+    ctime: Option<DateTime>,
+    #[arg(
+        long,
+        help = "Clamp the creation time of the entries to the specified time by --ctime"
+    )]
+    clamp_ctime: bool,
     #[arg(long, help = "Overrides the modification time")]
     mtime: Option<DateTime>,
     #[arg(
@@ -262,7 +270,9 @@ fn run_create_archive(args: StdioCommand) -> io::Result<()> {
     );
     let path_transformers = PathTransformers::new(args.substitutions, args.transforms);
     let time_options = TimeOptions {
+        ctime: args.ctime.map(|it| it.to_system_time()),
         mtime: args.mtime.map(|it| it.to_system_time()),
+        clamp_ctime: args.clamp_ctime,
         clamp_mtime: args.clamp_mtime,
     };
     let creation_context = CreationContext {
@@ -399,7 +409,9 @@ fn run_append(args: StdioCommand) -> io::Result<()> {
         args.numeric_owner,
     );
     let time_options = TimeOptions {
+        ctime: args.ctime.map(|it| it.to_system_time()),
         mtime: args.mtime.map(|it| it.to_system_time()),
+        clamp_ctime: args.clamp_ctime,
         clamp_mtime: args.clamp_mtime,
     };
     let create_options = CreateOptions {

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -115,6 +115,13 @@ pub(crate) struct UpdateCommand {
         help = "This is equivalent to --uname \"\" --gname \"\". It causes user and group names to not be stored in the archive"
     )]
     pub(crate) numeric_owner: bool,
+    #[arg(long, help = "Overrides the creation time read from disk")]
+    ctime: Option<DateTime>,
+    #[arg(
+        long,
+        help = "Clamp the creation time of the entries to the specified time by --ctime"
+    )]
+    clamp_ctime: bool,
     #[arg(
         long,
         help = "Only include files and directories older than the specified date. This compares ctime entries."
@@ -236,7 +243,9 @@ fn update_archive<Strategy: TransformStrategy>(args: UpdateCommand) -> io::Resul
         args.numeric_owner,
     );
     let time_options = TimeOptions {
+        ctime: args.ctime.map(|it| it.to_system_time()),
         mtime: args.mtime.map(|it| it.to_system_time()),
+        clamp_ctime: args.clamp_ctime,
         clamp_mtime: args.clamp_mtime,
     };
     let create_options = CreateOptions {

--- a/cli/tests/cli/append.rs
+++ b/cli/tests/cli/append.rs
@@ -1,5 +1,6 @@
 mod exclude;
 mod mtime;
+mod ctime;
 
 use crate::utils::{components_count, diff::diff, setup, TestResources};
 use clap::Parser;

--- a/cli/tests/cli/append/ctime.rs
+++ b/cli/tests/cli/append/ctime.rs
@@ -1,0 +1,153 @@
+use crate::utils::{archive::for_each_entry, setup, TestResources};
+use clap::Parser;
+use portable_network_archive::{cli, command::Command};
+use std::{
+    fs,
+    time::{Duration, SystemTime},
+};
+
+const DURATION_24_HOURS: Duration = Duration::from_secs(24 * 60 * 60);
+
+#[test]
+fn archive_append_with_ctime() {
+    setup();
+    TestResources::extract_in("raw/", "archive_append_with_ctime/in/").unwrap();
+
+    // Create initial archive
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "archive_append_with_ctime/append_with_ctime.pna",
+        "--overwrite",
+        "archive_append_with_ctime/in/",
+        "--keep-timestamp",
+        "--ctime",
+        "2024-01-01T00:00:00Z",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Copy extra input and update their ctime
+    TestResources::extract_in("store.pna", "archive_append_with_ctime/in/").unwrap();
+    TestResources::extract_in("zstd.pna", "archive_append_with_ctime/in/").unwrap();
+
+    let store_file = fs::File::options()
+        .write(true)
+        .open("archive_append_with_ctime/in/store.pna")
+        .unwrap();
+    store_file
+        .set_modified(SystemTime::now() + DURATION_24_HOURS)
+        .unwrap();
+
+    let zstd_file = fs::File::options()
+        .write(true)
+        .open("archive_append_with_ctime/in/zstd.pna")
+        .unwrap();
+    zstd_file
+        .set_modified(SystemTime::now() + DURATION_24_HOURS)
+        .unwrap();
+
+    // Append with specified ctime
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "append",
+        "--ctime",
+        "2024-01-01T00:00:00Z",
+        "--keep-timestamp",
+        "archive_append_with_ctime/append_with_ctime.pna",
+        "archive_append_with_ctime/in/store.pna",
+        "archive_append_with_ctime/in/zstd.pna",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Verify ctime is set correctly in the archive
+    let expected = Duration::from_secs(1704067200);
+    for_each_entry(
+        "archive_append_with_ctime/append_with_ctime.pna",
+        |entry| match entry.header().path().as_str() {
+            "archive_append_with_ctime/in/store.pna" | "archive_append_with_ctime/in/zstd.pna" => {
+                assert_eq!(entry.metadata().created(), Some(expected))
+            }
+            _ => assert!(entry.metadata().created().is_some()),
+        },
+    )
+    .unwrap();
+}
+
+#[test]
+fn archive_append_with_clamp_ctime() {
+    setup();
+    TestResources::extract_in("raw/", "archive_append_with_clamp_ctime/in/").unwrap();
+
+    // Create initial archive
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "archive_append_with_clamp_ctime/append_with_clamp_ctime.pna",
+        "--overwrite",
+        "archive_append_with_clamp_ctime/in/",
+        "--keep-timestamp",
+        "--ctime",
+        "2024-01-01T00:00:00Z",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Copy extra input and update their ctime
+    TestResources::extract_in("store.pna", "archive_append_with_clamp_ctime/in/").unwrap();
+    TestResources::extract_in("zstd.pna", "archive_append_with_clamp_ctime/in/").unwrap();
+
+    let store_file = fs::File::options()
+        .write(true)
+        .open("archive_append_with_clamp_ctime/in/store.pna")
+        .unwrap();
+    store_file
+        .set_modified(SystemTime::now() + DURATION_24_HOURS)
+        .unwrap();
+
+    let zstd_file = fs::File::options()
+        .write(true)
+        .open("archive_append_with_clamp_ctime/in/zstd.pna")
+        .unwrap();
+    zstd_file
+        .set_modified(SystemTime::now() + DURATION_24_HOURS)
+        .unwrap();
+
+    // Append with specified ctime and clamp
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "append",
+        "--ctime",
+        "2024-01-01T00:00:00Z",
+        "--clamp-ctime",
+        "--keep-timestamp",
+        "archive_append_with_clamp_ctime/append_with_clamp_ctime.pna",
+        "archive_append_with_clamp_ctime/in/store.pna",
+        "archive_append_with_clamp_ctime/in/zstd.pna",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Verify ctime is clamped correctly in the archive
+    let expected = Duration::from_secs(1704067200);
+    for_each_entry(
+        "archive_append_with_clamp_ctime/append_with_clamp_ctime.pna",
+        |entry| match entry.header().path().as_str() {
+            "archive_append_with_clamp_ctime/in/store.pna"
+            | "archive_append_with_clamp_ctime/in/zstd.pna" => {
+                assert!(entry.metadata().created() <= Some(expected))
+            }
+            _ => assert!(entry.metadata().created().is_some()),
+        },
+    )
+    .unwrap();
+}

--- a/cli/tests/cli/create.rs
+++ b/cli/tests/cli/create.rs
@@ -1,5 +1,6 @@
 mod exclude;
 mod mtime;
+mod ctime;
 mod no_recursive;
 mod password_from_file;
 mod password_hash;

--- a/cli/tests/cli/create/ctime.rs
+++ b/cli/tests/cli/create/ctime.rs
@@ -1,0 +1,92 @@
+use crate::utils::{archive::for_each_entry, setup, TestResources};
+use clap::Parser;
+use portable_network_archive::{cli, command::Command};
+use std::{
+    fs,
+    io::prelude::*,
+    time::{Duration, SystemTime},
+};
+
+const DURATION_24_HOURS: Duration = Duration::from_secs(24 * 60 * 60);
+
+#[test]
+fn archive_create_with_ctime() {
+    setup();
+    TestResources::extract_in("raw/", "archive_create_with_ctime/in/").unwrap();
+
+    // Update file with newer ctime
+    let mut file = fs::File::options()
+        .write(true)
+        .truncate(true)
+        .open("archive_create_with_ctime/in/raw/text.txt")
+        .unwrap();
+    file.write_all(b"updated!").unwrap();
+    file.set_modified(SystemTime::now() + DURATION_24_HOURS)
+        .unwrap();
+
+    // Create archive with specified ctime
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "archive_create_with_ctime/create_with_ctime.pna",
+        "--overwrite",
+        "archive_create_with_ctime/in/",
+        "--keep-timestamp",
+        "--ctime",
+        "2024-01-01T00:00:00Z",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Verify ctime is set correctly in the archive
+    let expected = Duration::from_secs(1704067200);
+    for_each_entry("archive_create_with_ctime/create_with_ctime.pna", |entry| {
+        assert_eq!(entry.metadata().created(), Some(expected));
+    })
+    .unwrap();
+}
+
+#[test]
+fn archive_create_with_clamp_ctime() {
+    setup();
+    TestResources::extract_in("raw/", "archive_create_with_clamp_ctime/in/").unwrap();
+
+    // Update file with newer ctime
+    let mut file = fs::File::options()
+        .write(true)
+        .truncate(true)
+        .open("archive_create_with_clamp_ctime/in/raw/text.txt")
+        .unwrap();
+    file.write_all(b"updated!").unwrap();
+    file.set_modified(SystemTime::now() + DURATION_24_HOURS)
+        .unwrap();
+
+    // Create archive with specified ctime and clamp
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "archive_create_with_clamp_ctime/create_with_clamp_ctime.pna",
+        "--overwrite",
+        "archive_create_with_clamp_ctime/in/",
+        "--keep-timestamp",
+        "--ctime",
+        "2024-01-01T00:00:00Z",
+        "--clamp-ctime",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Verify ctime is clamped correctly in the archive
+    let expected = Duration::from_secs(1704067200);
+    for_each_entry(
+        "archive_create_with_clamp_ctime/create_with_clamp_ctime.pna",
+        |entry| {
+            assert!(entry.metadata().created() <= Some(expected));
+        },
+    )
+    .unwrap();
+}

--- a/cli/tests/cli/update.rs
+++ b/cli/tests/cli/update.rs
@@ -1,5 +1,6 @@
 mod exclude;
 mod mtime;
+mod ctime;
 
 use crate::utils::{components_count, diff::diff, setup, TestResources};
 use clap::Parser;

--- a/cli/tests/cli/update/ctime.rs
+++ b/cli/tests/cli/update/ctime.rs
@@ -1,0 +1,118 @@
+use crate::utils::{archive::for_each_entry, setup, TestResources};
+use clap::Parser;
+use portable_network_archive::{cli, command::Command};
+use std::{
+    fs,
+    io::prelude::*,
+    time::{Duration, SystemTime},
+};
+
+const DURATION_24_HOURS: Duration = Duration::from_secs(24 * 60 * 60);
+
+#[test]
+fn archive_update_with_ctime() {
+    setup();
+    TestResources::extract_in("raw/", "archive_update_with_ctime/in/").unwrap();
+    // Create initial archive
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "archive_update_with_ctime/update_with_ctime.pna",
+        "--overwrite",
+        "archive_update_with_ctime/in/",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Update file with newer ctime
+    let mut file = fs::File::options()
+        .write(true)
+        .truncate(true)
+        .open("archive_update_with_ctime/in/raw/text.txt")
+        .unwrap();
+    file.write_all(b"updated!").unwrap();
+    file.set_modified(SystemTime::now() + DURATION_24_HOURS)
+        .unwrap();
+
+    // Update archive with specified ctime
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "--ctime",
+        "2024-01-01T00:00:00Z",
+        "archive_update_with_ctime/update_with_ctime.pna",
+        "archive_update_with_ctime/in/",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Verify ctime is set correctly in the archive
+    let expected = Duration::from_secs(1704067200);
+    for_each_entry("archive_update_with_ctime/update_with_ctime.pna", |entry| {
+        assert_eq!(entry.metadata().created(), Some(expected));
+    })
+    .unwrap();
+}
+
+#[test]
+fn archive_update_with_clamp_ctime() {
+    setup();
+    TestResources::extract_in("raw/", "archive_update_with_clamp_ctime/in/").unwrap();
+    // Create initial archive
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "archive_update_with_clamp_ctime/update_with_clamp_ctime.pna",
+        "--overwrite",
+        "archive_update_with_clamp_ctime/in/",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Update file with newer ctime
+    let mut file = fs::File::options()
+        .write(true)
+        .truncate(true)
+        .open("archive_update_with_clamp_ctime/in/raw/text.txt")
+        .unwrap();
+    file.write_all(b"updated!").unwrap();
+    file.set_modified(SystemTime::now() + DURATION_24_HOURS)
+        .unwrap();
+
+    // Update archive with specified ctime and clamp
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "--ctime",
+        "2024-01-01T00:00:00Z",
+        "--clamp-ctime",
+        "archive_update_with_clamp_ctime/update_with_clamp_ctime.pna",
+        "archive_update_with_clamp_ctime/in/",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Verify ctime is clamped correctly in the archive
+    let expected = Duration::from_secs(1704067200);
+    for_each_entry(
+        "archive_update_with_clamp_ctime/update_with_clamp_ctime.pna",
+        |entry| {
+            assert!(entry.metadata().created() <= Some(expected));
+        },
+    )
+    .unwrap();
+}


### PR DESCRIPTION
## Summary
- implement `--ctime` and `--clamp-ctime` options for create, update, append and stdio commands
- extend `TimeOptions` with creation time handling
- add corresponding tests mirroring existing mtime tests

## Testing
- `cargo fmt --all` *(fails: component missing)*
- `cargo test --locked --no-run` *(fails: could not download crates)*