### PR TITLE
Add tests for missing create options

### DIFF
--- a/cli/tests/cli/create.rs
+++ b/cli/tests/cli/create.rs
@@ -1,6 +1,12 @@
 mod exclude;
+mod exclude_from;
+mod files_from;
+mod files_from_stdin;
+mod gitignore;
+mod include;
 mod mtime;
 mod no_recursive;
+mod numeric_owner;
 mod password_from_file;
 mod password_hash;
 mod substitution;

--- a/cli/tests/cli/create/exclude_from.rs
+++ b/cli/tests/cli/create/exclude_from.rs
@@ -1,0 +1,57 @@
+use crate::utils::{self, diff::diff, setup, TestResources};
+use clap::Parser;
+use portable_network_archive::{cli, command::Command};
+use std::fs;
+
+#[test]
+fn create_with_exclude_from() {
+    setup();
+    TestResources::extract_in("raw/", "create_with_exclude_from/in/").unwrap();
+    let file_path = "create_with_exclude_from/exclude_list";
+    fs::write(file_path, "**/*.txt").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "create_with_exclude_from/exclude_from.pna",
+        "--overwrite",
+        "create_with_exclude_from/in/",
+        "--exclude-from",
+        file_path,
+        "--unstable",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        "create_with_exclude_from/exclude_from.pna",
+        "--overwrite",
+        "--out-dir",
+        "create_with_exclude_from/out/",
+        "--strip-components",
+        "2",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let excluded = [
+        "create_with_exclude_from/in/raw/first/second/third/pna.txt",
+        "create_with_exclude_from/in/raw/parent/child.txt",
+        "create_with_exclude_from/in/raw/empty.txt",
+        "create_with_exclude_from/in/raw/text.txt",
+    ];
+    for file in excluded {
+        utils::remove_with_empty_parents(file).unwrap();
+    }
+
+    diff(
+        "create_with_exclude_from/in/",
+        "create_with_exclude_from/out/",
+    )
+    .unwrap();
+}
+

--- a/cli/tests/cli/create/files_from.rs
+++ b/cli/tests/cli/create/files_from.rs
@@ -1,0 +1,75 @@
+use crate::utils::{self, diff::diff, setup, TestResources, components_count};
+use clap::Parser;
+use portable_network_archive::{cli, command::Command};
+use std::fs;
+
+#[test]
+fn create_with_files_from() {
+    setup();
+    TestResources::extract_in("raw/", "create_with_files_from/src/").unwrap();
+
+    let list_path = "create_with_files_from/files.txt";
+    fs::write(
+        list_path,
+        [
+            "create_with_files_from/src/raw/empty.txt",
+            "create_with_files_from/src/raw/text.txt",
+        ]
+        .join("\n"),
+    )
+    .unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "create_with_files_from/create_with_files_from.pna",
+        "--overwrite",
+        "--files-from",
+        list_path,
+        "--unstable",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        "create_with_files_from/create_with_files_from.pna",
+        "--overwrite",
+        "--out-dir",
+        "create_with_files_from/out/",
+        "--strip-components",
+        &components_count("create_with_files_from/src/").to_string(),
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    utils::copy_dir_all(
+        "create_with_files_from/src/",
+        "create_with_files_from/expected/",
+    )
+    .unwrap();
+    let to_remove = [
+        "create_with_files_from/expected/raw/first/second/third/pna.txt",
+        "create_with_files_from/expected/raw/parent/child.txt",
+        "create_with_files_from/expected/raw/images/icon.bmp",
+        "create_with_files_from/expected/raw/images/icon.png",
+        "create_with_files_from/expected/raw/images/icon.svg",
+        "create_with_files_from/expected/raw/pna/empty.pna",
+        "create_with_files_from/expected/raw/pna/nest.pna",
+    ];
+    for file in to_remove {
+        utils::remove_with_empty_parents(file).unwrap();
+    }
+
+    diff(
+        "create_with_files_from/expected/",
+        "create_with_files_from/out/",
+    )
+    .unwrap();
+}
+

--- a/cli/tests/cli/create/files_from_stdin.rs
+++ b/cli/tests/cli/create/files_from_stdin.rs
@@ -1,0 +1,64 @@
+use crate::utils::{self, diff::diff, setup, TestResources, components_count};
+use assert_cmd::Command;
+
+#[test]
+fn create_with_files_from_stdin() {
+    setup();
+    TestResources::extract_in("raw/", "create_with_files_from_stdin/src/").unwrap();
+
+    let list = [
+        "create_with_files_from_stdin/src/raw/empty.txt",
+        "create_with_files_from_stdin/src/raw/text.txt",
+    ]
+    .join("\n");
+
+    let mut cmd = Command::cargo_bin("pna").unwrap();
+    cmd.write_stdin(list);
+    cmd.args([
+        "--quiet",
+        "c",
+        "create_with_files_from_stdin/create_with_files_from_stdin.pna",
+        "--overwrite",
+        "--files-from-stdin",
+        "--unstable",
+    ]);
+    cmd.assert().success();
+
+    let mut cmd = Command::cargo_bin("pna").unwrap();
+    cmd.args([
+        "--quiet",
+        "x",
+        "create_with_files_from_stdin/create_with_files_from_stdin.pna",
+        "--overwrite",
+        "--out-dir",
+        "create_with_files_from_stdin/out/",
+        "--strip-components",
+        &components_count("create_with_files_from_stdin/src/").to_string(),
+    ]);
+    cmd.assert().success();
+
+    utils::copy_dir_all(
+        "create_with_files_from_stdin/src/",
+        "create_with_files_from_stdin/expected/",
+    )
+    .unwrap();
+    let to_remove = [
+        "create_with_files_from_stdin/expected/raw/first/second/third/pna.txt",
+        "create_with_files_from_stdin/expected/raw/parent/child.txt",
+        "create_with_files_from_stdin/expected/raw/images/icon.bmp",
+        "create_with_files_from_stdin/expected/raw/images/icon.png",
+        "create_with_files_from_stdin/expected/raw/images/icon.svg",
+        "create_with_files_from_stdin/expected/raw/pna/empty.pna",
+        "create_with_files_from_stdin/expected/raw/pna/nest.pna",
+    ];
+    for file in to_remove {
+        utils::remove_with_empty_parents(file).unwrap();
+    }
+
+    diff(
+        "create_with_files_from_stdin/expected/",
+        "create_with_files_from_stdin/out/",
+    )
+    .unwrap();
+}
+

--- a/cli/tests/cli/create/gitignore.rs
+++ b/cli/tests/cli/create/gitignore.rs
@@ -1,0 +1,45 @@
+use crate::utils::{diff::diff, setup};
+use clap::Parser;
+use portable_network_archive::{cli, command::Command};
+use std::fs;
+
+#[test]
+fn create_with_gitignore() {
+    setup();
+    fs::create_dir_all("gitignore/source").unwrap();
+    fs::write("gitignore/source/.gitignore", "*.log\n").unwrap();
+    fs::write("gitignore/source/keep.txt", b"text").unwrap();
+    fs::write("gitignore/source/skip.log", b"log").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "gitignore/gitignore.pna",
+        "--overwrite",
+        "gitignore/source",
+        "--gitignore",
+        "--unstable",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        "gitignore/gitignore.pna",
+        "--overwrite",
+        "--out-dir",
+        "gitignore/out/",
+        "--strip-components",
+        "2",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    fs::remove_file("gitignore/source/skip.log").unwrap();
+    diff("gitignore/source/", "gitignore/out/").unwrap();
+}
+

--- a/cli/tests/cli/create/include.rs
+++ b/cli/tests/cli/create/include.rs
@@ -1,0 +1,52 @@
+use crate::utils::{self, diff::diff, setup, TestResources};
+use clap::Parser;
+use portable_network_archive::{cli, command::Command};
+use std::fs;
+
+#[test]
+fn create_with_include() {
+    setup();
+    TestResources::extract_in("raw/", "create_with_include/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "create_with_include/include.pna",
+        "--overwrite",
+        "create_with_include/in/",
+        "--include",
+        "**/*.txt",
+        "--unstable",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        "create_with_include/include.pna",
+        "--overwrite",
+        "--out-dir",
+        "create_with_include/out/",
+        "--strip-components",
+        "2",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let excluded = [
+        "create_with_include/in/raw/images/icon.bmp",
+        "create_with_include/in/raw/images/icon.png",
+        "create_with_include/in/raw/images/icon.svg",
+        "create_with_include/in/raw/pna/empty.pna",
+        "create_with_include/in/raw/pna/nest.pna",
+    ];
+    for file in excluded {
+        utils::remove_with_empty_parents(file).unwrap();
+    }
+
+    diff("create_with_include/in/", "create_with_include/out/").unwrap();
+}
+

--- a/cli/tests/cli/create/numeric_owner.rs
+++ b/cli/tests/cli/create/numeric_owner.rs
@@ -1,0 +1,47 @@
+#![cfg(any(unix, windows))]
+use crate::utils::{archive, diff::diff, setup, TestResources, components_count};
+use clap::Parser;
+use portable_network_archive::{cli, command::Command};
+
+#[test]
+fn create_numeric_owner() {
+    setup();
+    TestResources::extract_in("raw/", "numeric_owner/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "numeric_owner/numeric_owner.pna",
+        "--overwrite",
+        "numeric_owner/in/",
+        "--keep-permission",
+        "--numeric-owner",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    archive::for_each_entry("numeric_owner/numeric_owner.pna", |entry| {
+        let p = entry.metadata().permission().unwrap();
+        assert_eq!(p.uname(), "");
+        assert_eq!(p.gname(), "");
+    })
+    .unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        "numeric_owner/numeric_owner.pna",
+        "--overwrite",
+        "--out-dir",
+        "numeric_owner/out/",
+        "--keep-permission",
+        "--strip-components",
+        &components_count("numeric_owner/in/").to_string(),
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    diff("numeric_owner/in/", "numeric_owner/out/").unwrap();
+}
+


### PR DESCRIPTION
## Summary
- add tests for `--files-from`, `--files-from-stdin`, `--include`, `--exclude-from`, `--gitignore`, and `--numeric-owner`
- register new test modules in the create test suite

## Testing
- `cargo test --quiet`