### PR TITLE
Add missing delete command tests

### DIFF
--- a/cli/tests/cli/delete.rs
+++ b/cli/tests/cli/delete.rs
@@ -1,4 +1,10 @@
 mod exclude;
+mod exclude_from;
+mod files_from;
+mod files_from_stdin;
+mod include;
+mod password;
+mod password_file;
 
 use crate::utils::{components_count, diff::diff, setup, TestResources};
 use clap::Parser;

--- a/cli/tests/cli/delete/exclude_from.rs
+++ b/cli/tests/cli/delete/exclude_from.rs
@@ -1,0 +1,60 @@
+use crate::utils::{diff::diff, setup, TestResources};
+use clap::Parser;
+use portable_network_archive::{cli, command::Command};
+use std::fs;
+
+#[test]
+fn delete_with_exclude_from() {
+    setup();
+    TestResources::extract_in("raw/", "delete_exclude_from/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "delete_exclude_from/exclude_from.pna",
+        "--overwrite",
+        "delete_exclude_from/in/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let file_path = "delete_exclude_from/exclude_list";
+    fs::write(file_path, "**/raw/text.txt").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "delete",
+        "delete_exclude_from/exclude_from.pna",
+        "**/*.txt",
+        "--exclude-from",
+        file_path,
+        "--unstable",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    fs::remove_file("delete_exclude_from/in/raw/empty.txt").unwrap();
+    fs::remove_file("delete_exclude_from/in/raw/parent/child.txt").unwrap();
+    fs::remove_file("delete_exclude_from/in/raw/first/second/third/pna.txt").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        "delete_exclude_from/exclude_from.pna",
+        "--overwrite",
+        "--out-dir",
+        "delete_exclude_from/out/",
+        "--strip-components",
+        "2",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    diff("delete_exclude_from/in/", "delete_exclude_from/out/").unwrap();
+}

--- a/cli/tests/cli/delete/files_from.rs
+++ b/cli/tests/cli/delete/files_from.rs
@@ -1,0 +1,62 @@
+use crate::utils::{components_count, diff::diff, setup, TestResources};
+use clap::Parser;
+use portable_network_archive::{cli, command::Command};
+use std::fs;
+
+#[test]
+fn delete_with_files_from() {
+    setup();
+    TestResources::extract_in("raw/", "delete_files_from/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "delete_files_from/delete_files_from.pna",
+        "--overwrite",
+        "delete_files_from/in/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let list_path = "delete_files_from/delete_list";
+    fs::write(
+        list_path,
+        ["**/raw/empty.txt", "**/raw/text.txt"].join("\n"),
+    )
+    .unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "delete",
+        "delete_files_from/delete_files_from.pna",
+        "--files-from",
+        list_path,
+        "--unstable",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    fs::remove_file("delete_files_from/in/raw/empty.txt").unwrap();
+    fs::remove_file("delete_files_from/in/raw/text.txt").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        "delete_files_from/delete_files_from.pna",
+        "--overwrite",
+        "--out-dir",
+        "delete_files_from/out/",
+        "--strip-components",
+        &components_count("delete_files_from/in/").to_string(),
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    diff("delete_files_from/in/", "delete_files_from/out/").unwrap();
+}

--- a/cli/tests/cli/delete/files_from_stdin.rs
+++ b/cli/tests/cli/delete/files_from_stdin.rs
@@ -1,0 +1,59 @@
+#![cfg(not(target_family = "wasm"))]
+use crate::utils::{components_count, diff::diff, setup, TestResources};
+use assert_cmd::Command as Cmd;
+use clap::Parser;
+use portable_network_archive::{cli, command::Command};
+use std::fs;
+
+#[test]
+fn delete_with_files_from_stdin() {
+    setup();
+    TestResources::extract_in("raw/", "delete_files_from_stdin/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "delete_files_from_stdin/delete_files_from_stdin.pna",
+        "--overwrite",
+        "delete_files_from_stdin/in/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let list = ["**/raw/empty.txt", "**/raw/text.txt"].join("\n");
+
+    let mut cmd = Cmd::cargo_bin("pna").unwrap();
+    cmd.write_stdin(list);
+    cmd.args([
+        "--quiet",
+        "experimental",
+        "delete",
+        "delete_files_from_stdin/delete_files_from_stdin.pna",
+        "--files-from-stdin",
+        "--unstable",
+    ]);
+    cmd.assert().success();
+
+    fs::remove_file("delete_files_from_stdin/in/raw/empty.txt").unwrap();
+    fs::remove_file("delete_files_from_stdin/in/raw/text.txt").unwrap();
+
+    let mut cmd = Cmd::cargo_bin("pna").unwrap();
+    cmd.args([
+        "--quiet",
+        "x",
+        "delete_files_from_stdin/delete_files_from_stdin.pna",
+        "--overwrite",
+        "--out-dir",
+        "delete_files_from_stdin/out/",
+        "--strip-components",
+        &components_count("delete_files_from_stdin/in/").to_string(),
+    ]);
+    cmd.assert().success();
+
+    diff(
+        "delete_files_from_stdin/in/",
+        "delete_files_from_stdin/out/",
+    )
+    .unwrap();
+}

--- a/cli/tests/cli/delete/include.rs
+++ b/cli/tests/cli/delete/include.rs
@@ -1,0 +1,52 @@
+use crate::utils::{diff::diff, setup, TestResources};
+use clap::Parser;
+use portable_network_archive::{cli, command::Command};
+use std::fs;
+
+#[test]
+fn delete_with_include() {
+    setup();
+    TestResources::extract_in("raw/", "delete_with_include/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "delete_with_include/include.pna",
+        "--overwrite",
+        "delete_with_include/in/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "delete",
+        "delete_with_include/include.pna",
+        "**/*.txt",
+        "--include",
+        "**/raw/text.txt",
+        "--unstable",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    fs::remove_file("delete_with_include/in/raw/text.txt").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        "delete_with_include/include.pna",
+        "--overwrite",
+        "--out-dir",
+        "delete_with_include/out/",
+        "--strip-components",
+        "2",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    diff("delete_with_include/in/", "delete_with_include/out/").unwrap();
+}

--- a/cli/tests/cli/delete/password.rs
+++ b/cli/tests/cli/delete/password.rs
@@ -1,0 +1,56 @@
+use crate::utils::{components_count, diff::diff, setup, TestResources};
+use clap::Parser;
+use portable_network_archive::{cli, command::Command};
+use std::fs;
+
+#[test]
+fn delete_with_password() {
+    setup();
+    TestResources::extract_in("raw/", "delete_password/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "delete_password/delete_password.pna",
+        "--overwrite",
+        "delete_password/in/",
+        "--password",
+        "password",
+        "--aes",
+        "ctr",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "delete",
+        "delete_password/delete_password.pna",
+        "**/raw/empty.txt",
+        "--password",
+        "password",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    fs::remove_file("delete_password/in/raw/empty.txt").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        "delete_password/delete_password.pna",
+        "--overwrite",
+        "--out-dir",
+        "delete_password/out/",
+        "--password",
+        "password",
+        "--strip-components",
+        &components_count("delete_password/in/").to_string(),
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    diff("delete_password/in/", "delete_password/out/").unwrap();
+}

--- a/cli/tests/cli/delete/password_file.rs
+++ b/cli/tests/cli/delete/password_file.rs
@@ -1,0 +1,59 @@
+use crate::utils::{components_count, diff::diff, setup, TestResources};
+use clap::Parser;
+use portable_network_archive::{cli, command::Command};
+use std::fs;
+
+#[test]
+fn delete_with_password_file() {
+    setup();
+    TestResources::extract_in("raw/", "delete_password_file/in/").unwrap();
+    let password_file_path = "delete_password_file/password_file";
+    let password = "delete_password_file";
+    fs::write(password_file_path, password).unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "delete_password_file/password_file.pna",
+        "--overwrite",
+        "delete_password_file/in/",
+        "--password",
+        password,
+        "--aes",
+        "ctr",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "delete",
+        "delete_password_file/password_file.pna",
+        "**/raw/empty.txt",
+        "--password-file",
+        password_file_path,
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    fs::remove_file("delete_password_file/in/raw/empty.txt").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        "delete_password_file/password_file.pna",
+        "--overwrite",
+        "--out-dir",
+        "delete_password_file/out/",
+        "--password-file",
+        password_file_path,
+        "--strip-components",
+        &components_count("delete_password_file/in/").to_string(),
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    diff("delete_password_file/in/", "delete_password_file/out/").unwrap();
+}


### PR DESCRIPTION
## Summary
- add coverage for `--files-from` and `--files-from-stdin`
- test `--include` option
- test `--exclude-from` option
- add password related delete tests

## Testing
- `cargo test --no-run`
- `cargo test`