### PR TITLE
Add nanosecond timestamp support

### DIFF
--- a/cli/src/command/acl.rs
+++ b/cli/src/command/acl.rs
@@ -47,6 +47,7 @@ impl Command for AclCommand {
 }
 
 #[derive(Parser, Clone, Eq, PartialEq, Hash, Debug)]
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum XattrCommands {
     #[command(about = "Get acl of entries")]
     Get(GetAclCommand),

--- a/lib/src/chunk/types.rs
+++ b/lib/src/chunk/types.rs
@@ -70,6 +70,15 @@ impl ChunkType {
     /// Last accessed datetime
     #[allow(non_upper_case_globals)]
     pub const aTIM: ChunkType = ChunkType(*b"aTIM");
+    /// Nanoseconds for creation datetime
+    #[allow(non_upper_case_globals)]
+    pub const cTNS: ChunkType = ChunkType(*b"cTNS");
+    /// Nanoseconds for last modified datetime
+    #[allow(non_upper_case_globals)]
+    pub const mTNS: ChunkType = ChunkType(*b"mTNS");
+    /// Nanoseconds for last accessed datetime
+    #[allow(non_upper_case_globals)]
+    pub const aTNS: ChunkType = ChunkType(*b"aTNS");
     /// Entry permissions
     #[allow(non_upper_case_globals)]
     pub const fPRM: ChunkType = ChunkType(*b"fPRM");


### PR DESCRIPTION
## Summary
- support cTNS/mTNS/aTNS chunk types
- preserve and write nanosecond timestamps when reading/writing entries
- silence clippy large_enum_variant in CLI

## Testing
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace --quiet`
