### PR TITLE
Fix labeler permissions

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -6,6 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: write
       pull-requests: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Summary
- add `issues: write` permission for labeler workflow

## Testing
- `cargo clippy --all-targets -- -D warnings` *(fails: `lib/benches/create_extract.rs:1:1` `error[E0554]: #![feature] may not be used on the stable release channel`)*
- `cargo test --workspace`