### PR TITLE
Switch benchmarks to criterion

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -62,6 +62,7 @@ maplit = "1.0.2"
 path-slash = "0.2.1"
 rust-embed = { version = "8.7.2", features = ["debug-embed"] }
 walkdir = "2.5.0"
+criterion = "0.5"
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 assert_cmd = "2.0.17"
@@ -78,3 +79,19 @@ zlib-ng = ["pna/zlib-ng"]
 [[bin]]
 name = "pna"
 path = "src/main.rs"
+
+[[bench]]
+name = "create"
+harness = false
+
+[[bench]]
+name = "extract"
+harness = false
+
+[[bench]]
+name = "list"
+harness = false
+
+[[bench]]
+name = "split"
+harness = false

--- a/cli/benches/create.rs
+++ b/cli/benches/create.rs
@@ -1,110 +1,124 @@
-#![feature(test)]
-extern crate test;
-
 use clap::Parser;
+use criterion::{criterion_group, criterion_main, Criterion};
 use portable_network_archive::{cli, command};
-use test::Bencher;
 
-#[bench]
-fn store(b: &mut Bencher) {
-    b.iter(|| {
-        command::entry(cli::Cli::parse_from([
-            "pna",
-            "--quiet",
-            "c",
-            &format!("{}/bench/store.pna", env!("CARGO_TARGET_TMPDIR")),
-            "--store",
-            "--overwrite",
-            "../resources/test/raw/",
-        ]))
-        .unwrap()
-    })
+fn bench_store(c: &mut Criterion) {
+    c.bench_function("store", |b| {
+        b.iter(|| {
+            command::entry(cli::Cli::parse_from([
+                "pna",
+                "--quiet",
+                "c",
+                &format!("{}/bench/store.pna", env!("CARGO_TARGET_TMPDIR")),
+                "--store",
+                "--overwrite",
+                "../resources/test/raw/",
+            ]))
+            .unwrap()
+        })
+    });
 }
 
-#[bench]
-fn zstd(b: &mut Bencher) {
-    b.iter(|| {
-        command::entry(cli::Cli::parse_from([
-            "pna",
-            "--quiet",
-            "c",
-            &format!("{}/bench/zstd.pna", env!("CARGO_TARGET_TMPDIR")),
-            "--zstd",
-            "--overwrite",
-            "../resources/test/raw/",
-        ]))
-        .unwrap()
-    })
+fn bench_zstd(c: &mut Criterion) {
+    c.bench_function("zstd", |b| {
+        b.iter(|| {
+            command::entry(cli::Cli::parse_from([
+                "pna",
+                "--quiet",
+                "c",
+                &format!("{}/bench/zstd.pna", env!("CARGO_TARGET_TMPDIR")),
+                "--zstd",
+                "--overwrite",
+                "../resources/test/raw/",
+            ]))
+            .unwrap()
+        })
+    });
 }
 
-#[bench]
-fn deflate(b: &mut Bencher) {
-    b.iter(|| {
-        command::entry(cli::Cli::parse_from([
-            "pna",
-            "--quiet",
-            "c",
-            &format!("{}/bench/deflate.pna", env!("CARGO_TARGET_TMPDIR")),
-            "--deflate",
-            "--overwrite",
-            "../resources/test/raw/",
-        ]))
-        .unwrap()
-    })
+fn bench_deflate(c: &mut Criterion) {
+    c.bench_function("deflate", |b| {
+        b.iter(|| {
+            command::entry(cli::Cli::parse_from([
+                "pna",
+                "--quiet",
+                "c",
+                &format!("{}/bench/deflate.pna", env!("CARGO_TARGET_TMPDIR")),
+                "--deflate",
+                "--overwrite",
+                "../resources/test/raw/",
+            ]))
+            .unwrap()
+        })
+    });
 }
 
-#[bench]
-fn xz(b: &mut Bencher) {
-    b.iter(|| {
-        command::entry(cli::Cli::parse_from([
-            "pna",
-            "--quiet",
-            "c",
-            &format!("{}/bench/xz.pna", env!("CARGO_TARGET_TMPDIR")),
-            "--xz",
-            "--overwrite",
-            "../resources/test/raw/",
-        ]))
-        .unwrap()
-    })
+fn bench_xz(c: &mut Criterion) {
+    c.bench_function("xz", |b| {
+        b.iter(|| {
+            command::entry(cli::Cli::parse_from([
+                "pna",
+                "--quiet",
+                "c",
+                &format!("{}/bench/xz.pna", env!("CARGO_TARGET_TMPDIR")),
+                "--xz",
+                "--overwrite",
+                "../resources/test/raw/",
+            ]))
+            .unwrap()
+        })
+    });
 }
 
-#[bench]
-fn zstd_keep_timestamp(b: &mut Bencher) {
-    b.iter(|| {
-        command::entry(cli::Cli::parse_from([
-            "pna",
-            "--quiet",
-            "c",
-            &format!(
-                "{}/bench/zstd_keep_timestamp.pna",
-                env!("CARGO_TARGET_TMPDIR")
-            ),
-            "--zstd",
-            "--keep-timestamp",
-            "--overwrite",
-            "../resources/test/raw/",
-        ]))
-        .unwrap()
-    })
+fn bench_zstd_keep_timestamp(c: &mut Criterion) {
+    c.bench_function("zstd_keep_timestamp", |b| {
+        b.iter(|| {
+            command::entry(cli::Cli::parse_from([
+                "pna",
+                "--quiet",
+                "c",
+                &format!(
+                    "{}/bench/zstd_keep_timestamp.pna",
+                    env!("CARGO_TARGET_TMPDIR")
+                ),
+                "--zstd",
+                "--keep-timestamp",
+                "--overwrite",
+                "../resources/test/raw/",
+            ]))
+            .unwrap()
+        })
+    });
 }
 
-#[bench]
-fn zstd_keep_permission(b: &mut Bencher) {
-    b.iter(|| {
-        command::entry(cli::Cli::parse_from([
-            "pna",
-            "--quiet",
-            "c",
-            &format!(
-                "{}/bench/zstd_keep_permission.pna",
-                env!("CARGO_TARGET_TMPDIR")
-            ),
-            "--zstd",
-            "--keep-permission",
-            "--overwrite",
-            "../resources/test/raw/",
-        ]))
-        .unwrap()
-    })
+fn bench_zstd_keep_permission(c: &mut Criterion) {
+    c.bench_function("zstd_keep_permission", |b| {
+        b.iter(|| {
+            command::entry(cli::Cli::parse_from([
+                "pna",
+                "--quiet",
+                "c",
+                &format!(
+                    "{}/bench/zstd_keep_permission.pna",
+                    env!("CARGO_TARGET_TMPDIR")
+                ),
+                "--zstd",
+                "--keep-permission",
+                "--overwrite",
+                "../resources/test/raw/",
+            ]))
+            .unwrap()
+        })
+    });
 }
+
+criterion_group!(
+    benches,
+    bench_store,
+    bench_zstd,
+    bench_deflate,
+    bench_xz,
+    bench_zstd_keep_timestamp,
+    bench_zstd_keep_permission
+);
+criterion_main!(benches);

--- a/cli/benches/extract.rs
+++ b/cli/benches/extract.rs
@@ -1,124 +1,140 @@
-#![feature(test)]
-extern crate test;
-
 use clap::Parser;
+use criterion::{criterion_group, criterion_main, Criterion};
 use portable_network_archive::{cli, command};
-use test::Bencher;
 
-#[bench]
-fn store(b: &mut Bencher) {
-    b.iter(|| {
-        command::entry(cli::Cli::parse_from([
-            "pna",
-            "--quiet",
-            "x",
-            "../resources/test/store.pna",
-            "--overwrite",
-            "--out-dir",
-            &format!("{}/bench/store/", env!("CARGO_TARGET_TMPDIR")),
-        ]))
-        .unwrap()
-    })
+fn bench_store(c: &mut Criterion) {
+    c.bench_function("store", |b| {
+        b.iter(|| {
+            command::entry(cli::Cli::parse_from([
+                "pna",
+                "--quiet",
+                "x",
+                "../resources/test/store.pna",
+                "--overwrite",
+                "--out-dir",
+                &format!("{}/bench/store/", env!("CARGO_TARGET_TMPDIR")),
+            ]))
+            .unwrap()
+        })
+    });
 }
 
-#[bench]
-fn zstd(b: &mut Bencher) {
-    b.iter(|| {
-        command::entry(cli::Cli::parse_from([
-            "pna",
-            "--quiet",
-            "x",
-            "../resources/test/zstd.pna",
-            "--overwrite",
-            "--out-dir",
-            &format!("{}/bench/zstd/", env!("CARGO_TARGET_TMPDIR")),
-        ]))
-        .unwrap()
-    })
+fn bench_zstd(c: &mut Criterion) {
+    c.bench_function("zstd", |b| {
+        b.iter(|| {
+            command::entry(cli::Cli::parse_from([
+                "pna",
+                "--quiet",
+                "x",
+                "../resources/test/zstd.pna",
+                "--overwrite",
+                "--out-dir",
+                &format!("{}/bench/zstd/", env!("CARGO_TARGET_TMPDIR")),
+            ]))
+            .unwrap()
+        })
+    });
 }
 
-#[bench]
-fn deflate(b: &mut Bencher) {
-    b.iter(|| {
-        command::entry(cli::Cli::parse_from([
-            "pna",
-            "--quiet",
-            "x",
-            "../resources/test/deflate.pna",
-            "--overwrite",
-            "--out-dir",
-            &format!("{}/bench/deflate/", env!("CARGO_TARGET_TMPDIR")),
-        ]))
-        .unwrap()
-    })
+fn bench_deflate(c: &mut Criterion) {
+    c.bench_function("deflate", |b| {
+        b.iter(|| {
+            command::entry(cli::Cli::parse_from([
+                "pna",
+                "--quiet",
+                "x",
+                "../resources/test/deflate.pna",
+                "--overwrite",
+                "--out-dir",
+                &format!("{}/bench/deflate/", env!("CARGO_TARGET_TMPDIR")),
+            ]))
+            .unwrap()
+        })
+    });
 }
 
-#[bench]
-fn xz(b: &mut Bencher) {
-    b.iter(|| {
-        command::entry(cli::Cli::parse_from([
-            "pna",
-            "--quiet",
-            "x",
-            "../resources/test/xz.pna",
-            "--overwrite",
-            "--out-dir",
-            &format!("{}/bench/xz/", env!("CARGO_TARGET_TMPDIR")),
-        ]))
-        .unwrap()
-    })
+fn bench_xz(c: &mut Criterion) {
+    c.bench_function("xz", |b| {
+        b.iter(|| {
+            command::entry(cli::Cli::parse_from([
+                "pna",
+                "--quiet",
+                "x",
+                "../resources/test/xz.pna",
+                "--overwrite",
+                "--out-dir",
+                &format!("{}/bench/xz/", env!("CARGO_TARGET_TMPDIR")),
+            ]))
+            .unwrap()
+        })
+    });
 }
 
-#[bench]
-fn zstd_keep_timestamp(b: &mut Bencher) {
-    b.iter(|| {
-        command::entry(cli::Cli::parse_from([
-            "pna",
-            "--quiet",
-            "x",
-            "../resources/test/zstd_keep_timestamp.pna",
-            "--overwrite",
-            "--out-dir",
-            &format!("{}/bench/zstd_keep_timestamp/", env!("CARGO_TARGET_TMPDIR")),
-        ]))
-        .unwrap()
-    })
+fn bench_zstd_keep_timestamp(c: &mut Criterion) {
+    c.bench_function("zstd_keep_timestamp", |b| {
+        b.iter(|| {
+            command::entry(cli::Cli::parse_from([
+                "pna",
+                "--quiet",
+                "x",
+                "../resources/test/zstd_keep_timestamp.pna",
+                "--overwrite",
+                "--out-dir",
+                &format!("{}/bench/zstd_keep_timestamp/", env!("CARGO_TARGET_TMPDIR")),
+            ]))
+            .unwrap()
+        })
+    });
 }
 
-#[bench]
-fn zstd_keep_permission(b: &mut Bencher) {
-    b.iter(|| {
-        command::entry(cli::Cli::parse_from([
-            "pna",
-            "--quiet",
-            "x",
-            "../resources/test/zstd_keep_permission.pna",
-            "--overwrite",
-            "--keep-permission",
-            "--out-dir",
-            &format!(
-                "{}/bench/zstd_keep_permission/",
-                env!("CARGO_TARGET_TMPDIR")
-            ),
-        ]))
-        .unwrap()
-    })
+fn bench_zstd_keep_permission(c: &mut Criterion) {
+    c.bench_function("zstd_keep_permission", |b| {
+        b.iter(|| {
+            command::entry(cli::Cli::parse_from([
+                "pna",
+                "--quiet",
+                "x",
+                "../resources/test/zstd_keep_permission.pna",
+                "--overwrite",
+                "--keep-permission",
+                "--out-dir",
+                &format!(
+                    "{}/bench/zstd_keep_permission/",
+                    env!("CARGO_TARGET_TMPDIR")
+                ),
+            ]))
+            .unwrap()
+        })
+    });
 }
 
-#[bench]
-fn zstd_keep_xattr(b: &mut Bencher) {
-    b.iter(|| {
-        command::entry(cli::Cli::parse_from([
-            "pna",
-            "--quiet",
-            "x",
-            "../resources/test/zstd_keep_xattr.pna",
-            "--overwrite",
-            #[cfg(not(target_os = "netbsd"))]
-            "--keep-xattr",
-            "--out-dir",
-            &format!("{}/bench/zstd_keep_xattr/", env!("CARGO_TARGET_TMPDIR")),
-        ]))
-        .unwrap()
-    })
+fn bench_zstd_keep_xattr(c: &mut Criterion) {
+    c.bench_function("zstd_keep_xattr", |b| {
+        b.iter(|| {
+            command::entry(cli::Cli::parse_from([
+                "pna",
+                "--quiet",
+                "x",
+                "../resources/test/zstd_keep_xattr.pna",
+                "--overwrite",
+                #[cfg(not(target_os = "netbsd"))]
+                "--keep-xattr",
+                "--out-dir",
+                &format!("{}/bench/zstd_keep_xattr/", env!("CARGO_TARGET_TMPDIR")),
+            ]))
+            .unwrap()
+        })
+    });
 }
+
+criterion_group!(
+    benches,
+    bench_store,
+    bench_zstd,
+    bench_deflate,
+    bench_xz,
+    bench_zstd_keep_timestamp,
+    bench_zstd_keep_permission,
+    bench_zstd_keep_xattr
+);
+criterion_main!(benches);

--- a/cli/benches/list.rs
+++ b/cli/benches/list.rs
@@ -1,33 +1,35 @@
-#![feature(test)]
-extern crate test;
-
 use clap::Parser;
+use criterion::{criterion_group, criterion_main, Criterion};
 use portable_network_archive::{cli, command};
-use test::Bencher;
 
-#[bench]
-fn normal(b: &mut Bencher) {
-    b.iter(|| {
-        command::entry(cli::Cli::parse_from([
-            "pna",
-            "--quiet",
-            "ls",
-            "../resources/test/zstd.pna",
-        ]))
-        .unwrap()
-    })
+fn bench_normal(c: &mut Criterion) {
+    c.bench_function("normal", |b| {
+        b.iter(|| {
+            command::entry(cli::Cli::parse_from([
+                "pna",
+                "--quiet",
+                "ls",
+                "../resources/test/zstd.pna",
+            ]))
+            .unwrap()
+        })
+    });
 }
 
-#[bench]
-fn solid(b: &mut Bencher) {
-    b.iter(|| {
-        command::entry(cli::Cli::parse_from([
-            "pna",
-            "--quiet",
-            "ls",
-            "--solid",
-            "../resources/test/solid_zstd.pna",
-        ]))
-        .unwrap()
-    })
+fn bench_solid(c: &mut Criterion) {
+    c.bench_function("solid", |b| {
+        b.iter(|| {
+            command::entry(cli::Cli::parse_from([
+                "pna",
+                "--quiet",
+                "ls",
+                "--solid",
+                "../resources/test/solid_zstd.pna",
+            ]))
+            .unwrap()
+        })
+    });
 }
+
+criterion_group!(benches, bench_normal, bench_solid);
+criterion_main!(benches);

--- a/cli/benches/split.rs
+++ b/cli/benches/split.rs
@@ -1,61 +1,69 @@
-#![feature(test)]
-extern crate test;
-
 use clap::Parser;
+use criterion::{criterion_group, criterion_main, Criterion};
 use portable_network_archive::{cli, command};
-use test::Bencher;
 
-#[bench]
-fn create_with_split(b: &mut Bencher) {
-    b.iter(|| {
-        command::entry(cli::Cli::parse_from([
-            "pna",
-            "--quiet",
-            "c",
-            &format!(
-                "{}/bench/create_with_split/store.pna",
-                env!("CARGO_TARGET_TMPDIR")
-            ),
-            "--store",
-            "--split",
-            "3MB",
-            "--overwrite",
-            "../resources/test/raw/",
-        ]))
-        .unwrap()
-    })
+fn bench_create_with_split(c: &mut Criterion) {
+    c.bench_function("create_with_split", |b| {
+        b.iter(|| {
+            command::entry(cli::Cli::parse_from([
+                "pna",
+                "--quiet",
+                "c",
+                &format!(
+                    "{}/bench/create_with_split/store.pna",
+                    env!("CARGO_TARGET_TMPDIR")
+                ),
+                "--store",
+                "--split",
+                "3MB",
+                "--overwrite",
+                "../resources/test/raw/",
+            ]))
+            .unwrap()
+        })
+    });
 }
 
-#[bench]
-fn split(b: &mut Bencher) {
-    b.iter(|| {
-        command::entry(cli::Cli::parse_from([
-            "pna",
-            "--quiet",
-            "split",
-            "../resources/test/store.pna",
-            "--overwrite",
-            "--max-size",
-            "3MB",
-            "--out-dir",
-            &format!("{}/bench/split/", env!("CARGO_TARGET_TMPDIR")),
-        ]))
-        .unwrap()
-    })
+fn bench_split(c: &mut Criterion) {
+    c.bench_function("split", |b| {
+        b.iter(|| {
+            command::entry(cli::Cli::parse_from([
+                "pna",
+                "--quiet",
+                "split",
+                "../resources/test/store.pna",
+                "--overwrite",
+                "--max-size",
+                "3MB",
+                "--out-dir",
+                &format!("{}/bench/split/", env!("CARGO_TARGET_TMPDIR")),
+            ]))
+            .unwrap()
+        })
+    });
 }
 
-#[bench]
-fn extract_multipart(b: &mut Bencher) {
-    b.iter(|| {
-        command::entry(cli::Cli::parse_from([
-            "pna",
-            "--quiet",
-            "x",
-            "../resources/test/multipart.part1.pna",
-            "--overwrite",
-            "--out-dir",
-            &format!("{}/bench/multipart/", env!("CARGO_TARGET_TMPDIR")),
-        ]))
-        .unwrap()
-    })
+fn bench_extract_multipart(c: &mut Criterion) {
+    c.bench_function("extract_multipart", |b| {
+        b.iter(|| {
+            command::entry(cli::Cli::parse_from([
+                "pna",
+                "--quiet",
+                "x",
+                "../resources/test/multipart.part1.pna",
+                "--overwrite",
+                "--out-dir",
+                &format!("{}/bench/multipart/", env!("CARGO_TARGET_TMPDIR")),
+            ]))
+            .unwrap()
+        })
+    });
 }
+
+criterion_group!(
+    benches,
+    bench_create_with_split,
+    bench_split,
+    bench_extract_multipart
+);
+criterion_main!(benches);

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -42,6 +42,7 @@ pbkdf2 = { version = "0.12.2", features = ["simple", "parallel"] }
 
 [dev-dependencies]
 version-sync = "0.9.5"
+criterion = "0.5"
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread", "fs", "io-util"] }
@@ -60,3 +61,7 @@ required-features = ["unstable-async"]
 
 [[example]]
 name = "change_compression_method"
+
+[[bench]]
+name = "create_extract"
+harness = false

--- a/lib/benches/create_extract.rs
+++ b/lib/benches/create_extract.rs
@@ -1,12 +1,9 @@
-#![feature(test)]
-extern crate test;
-
+use criterion::{criterion_group, criterion_main, Bencher, Criterion};
 use libpna::{
     Archive, CipherMode, Compression, Encryption, EntryBuilder, ReadEntry, ReadOptions,
     WriteOptions, WriteOptionsBuilder,
 };
 use std::io::{self, prelude::*};
-use test::Bencher;
 
 fn bench_write_archive(b: &mut Bencher, mut options: WriteOptionsBuilder) {
     let buf = [24; 1111];
@@ -86,213 +83,263 @@ fn bench_read_archive_from_slice(b: &mut Bencher, mut options: WriteOptionsBuild
     })
 }
 
-#[bench]
-fn write_store_archive(b: &mut Bencher) {
-    bench_write_archive(b, WriteOptions::builder());
-}
-
-#[bench]
-fn read_store_archive(b: &mut Bencher) {
-    bench_read_archive(b, WriteOptions::builder());
-}
-
-#[bench]
-fn read_store_archive_from_slice(b: &mut Bencher) {
-    bench_read_archive_from_slice(b, WriteOptions::builder());
-}
-
-#[bench]
-fn write_zstd_archive(b: &mut Bencher) {
-    bench_write_archive(b, {
-        let mut builder = WriteOptions::builder();
-        builder.compression(Compression::ZStandard);
-        builder
+fn bench_write_store_archive(c: &mut Criterion) {
+    c.bench_function("write_store_archive", |b| {
+        bench_write_archive(b, WriteOptions::builder());
     });
 }
 
-#[bench]
-fn read_zstd_archive(b: &mut Bencher) {
-    bench_read_archive(b, {
-        let mut builder = WriteOptions::builder();
-        builder.compression(Compression::ZStandard);
-        builder
+fn bench_read_store_archive(c: &mut Criterion) {
+    c.bench_function("read_store_archive", |b| {
+        bench_read_archive(b, WriteOptions::builder());
     });
 }
 
-#[bench]
-fn read_zstd_archive_from_slice(b: &mut Bencher) {
-    bench_read_archive_from_slice(b, {
-        let mut builder = WriteOptions::builder();
-        builder.compression(Compression::ZStandard);
-        builder
+fn bench_read_store_archive_from_slice(c: &mut Criterion) {
+    c.bench_function("read_store_archive_from_slice", |b| {
+        bench_read_archive_from_slice(b, WriteOptions::builder());
     });
 }
 
-#[bench]
-fn write_deflate_archive(b: &mut Bencher) {
-    bench_write_archive(b, {
-        let mut builder = WriteOptions::builder();
-        builder.compression(Compression::Deflate);
-        builder
+fn bench_write_zstd_archive(c: &mut Criterion) {
+    c.bench_function("write_zstd_archive", |b| {
+        bench_write_archive(b, {
+            let mut builder = WriteOptions::builder();
+            builder.compression(Compression::ZStandard);
+            builder
+        });
     });
 }
 
-#[bench]
-fn read_deflate_archive(b: &mut Bencher) {
-    bench_read_archive(b, {
-        let mut builder = WriteOptions::builder();
-        builder.compression(Compression::Deflate);
-        builder
+fn bench_read_zstd_archive(c: &mut Criterion) {
+    c.bench_function("read_zstd_archive", |b| {
+        bench_read_archive(b, {
+            let mut builder = WriteOptions::builder();
+            builder.compression(Compression::ZStandard);
+            builder
+        });
     });
 }
 
-#[bench]
-fn read_deflate_archive_from_slice(b: &mut Bencher) {
-    bench_read_archive_from_slice(b, {
-        let mut builder = WriteOptions::builder();
-        builder.compression(Compression::Deflate);
-        builder
+fn bench_read_zstd_archive_from_slice(c: &mut Criterion) {
+    c.bench_function("read_zstd_archive_from_slice", |b| {
+        bench_read_archive_from_slice(b, {
+            let mut builder = WriteOptions::builder();
+            builder.compression(Compression::ZStandard);
+            builder
+        });
     });
 }
 
-#[bench]
-fn write_xz_archive(b: &mut Bencher) {
-    bench_write_archive(b, {
-        let mut builder = WriteOptions::builder();
-        builder.compression(Compression::XZ);
-        builder
+fn bench_write_deflate_archive(c: &mut Criterion) {
+    c.bench_function("write_deflate_archive", |b| {
+        bench_write_archive(b, {
+            let mut builder = WriteOptions::builder();
+            builder.compression(Compression::Deflate);
+            builder
+        });
     });
 }
 
-#[bench]
-fn read_xz_archive(b: &mut Bencher) {
-    bench_read_archive(b, {
-        let mut builder = WriteOptions::builder();
-        builder.compression(Compression::XZ);
-        builder
+fn bench_read_deflate_archive(c: &mut Criterion) {
+    c.bench_function("read_deflate_archive", |b| {
+        bench_read_archive(b, {
+            let mut builder = WriteOptions::builder();
+            builder.compression(Compression::Deflate);
+            builder
+        });
     });
 }
 
-#[bench]
-fn read_xz_archive_from_slice(b: &mut Bencher) {
-    bench_read_archive_from_slice(b, {
-        let mut builder = WriteOptions::builder();
-        builder.compression(Compression::XZ);
-        builder
+fn bench_read_deflate_archive_from_slice(c: &mut Criterion) {
+    c.bench_function("read_deflate_archive_from_slice", |b| {
+        bench_read_archive_from_slice(b, {
+            let mut builder = WriteOptions::builder();
+            builder.compression(Compression::Deflate);
+            builder
+        });
     });
 }
 
-#[bench]
-fn write_aes_ctr_archive(b: &mut Bencher) {
-    bench_write_archive(b, {
-        let mut builder = WriteOptions::builder();
-        builder
-            .encryption(Encryption::Aes)
-            .cipher_mode(CipherMode::CTR);
-        builder
+fn bench_write_xz_archive(c: &mut Criterion) {
+    c.bench_function("write_xz_archive", |b| {
+        bench_write_archive(b, {
+            let mut builder = WriteOptions::builder();
+            builder.compression(Compression::XZ);
+            builder
+        });
     });
 }
 
-#[bench]
-fn read_aes_ctr_archive(b: &mut Bencher) {
-    bench_read_archive(b, {
-        let mut builder = WriteOptions::builder();
-        builder
-            .encryption(Encryption::Aes)
-            .cipher_mode(CipherMode::CTR);
-        builder
+fn bench_read_xz_archive(c: &mut Criterion) {
+    c.bench_function("read_xz_archive", |b| {
+        bench_read_archive(b, {
+            let mut builder = WriteOptions::builder();
+            builder.compression(Compression::XZ);
+            builder
+        });
     });
 }
 
-#[bench]
-fn write_aes_cbc_archive(b: &mut Bencher) {
-    bench_write_archive(b, {
-        let mut builder = WriteOptions::builder();
-        builder
-            .encryption(Encryption::Aes)
-            .cipher_mode(CipherMode::CBC);
-        builder
+fn bench_read_xz_archive_from_slice(c: &mut Criterion) {
+    c.bench_function("read_xz_archive_from_slice", |b| {
+        bench_read_archive_from_slice(b, {
+            let mut builder = WriteOptions::builder();
+            builder.compression(Compression::XZ);
+            builder
+        });
     });
 }
 
-#[bench]
-fn read_aes_cbc_archive(b: &mut Bencher) {
-    bench_read_archive(b, {
-        let mut builder = WriteOptions::builder();
-        builder
-            .encryption(Encryption::Aes)
-            .cipher_mode(CipherMode::CBC);
-        builder
+fn bench_write_aes_ctr_archive(c: &mut Criterion) {
+    c.bench_function("write_aes_ctr_archive", |b| {
+        bench_write_archive(b, {
+            let mut builder = WriteOptions::builder();
+            builder
+                .encryption(Encryption::Aes)
+                .cipher_mode(CipherMode::CTR);
+            builder
+        });
     });
 }
 
-#[bench]
-fn write_camellia_ctr_archive(b: &mut Bencher) {
-    bench_write_archive(b, {
-        let mut builder = WriteOptions::builder();
-        builder
-            .encryption(Encryption::Camellia)
-            .cipher_mode(CipherMode::CTR);
-        builder
+fn bench_read_aes_ctr_archive(c: &mut Criterion) {
+    c.bench_function("read_aes_ctr_archive", |b| {
+        bench_read_archive(b, {
+            let mut builder = WriteOptions::builder();
+            builder
+                .encryption(Encryption::Aes)
+                .cipher_mode(CipherMode::CTR);
+            builder
+        });
     });
 }
 
-#[bench]
-fn read_camellia_ctr_archive(b: &mut Bencher) {
-    bench_read_archive(b, {
-        let mut builder = WriteOptions::builder();
-        builder
-            .encryption(Encryption::Camellia)
-            .cipher_mode(CipherMode::CTR);
-        builder
+fn bench_write_aes_cbc_archive(c: &mut Criterion) {
+    c.bench_function("write_aes_cbc_archive", |b| {
+        bench_write_archive(b, {
+            let mut builder = WriteOptions::builder();
+            builder
+                .encryption(Encryption::Aes)
+                .cipher_mode(CipherMode::CBC);
+            builder
+        });
     });
 }
 
-#[bench]
-fn write_camellia_cbc_archive(b: &mut Bencher) {
-    bench_write_archive(b, {
-        let mut builder = WriteOptions::builder();
-        builder
-            .encryption(Encryption::Camellia)
-            .cipher_mode(CipherMode::CBC);
-        builder
+fn bench_read_aes_cbc_archive(c: &mut Criterion) {
+    c.bench_function("read_aes_cbc_archive", |b| {
+        bench_read_archive(b, {
+            let mut builder = WriteOptions::builder();
+            builder
+                .encryption(Encryption::Aes)
+                .cipher_mode(CipherMode::CBC);
+            builder
+        });
     });
 }
 
-#[bench]
-fn read_camellia_cbc_archive(b: &mut Bencher) {
-    bench_read_archive(b, {
-        let mut builder = WriteOptions::builder();
-        builder
-            .encryption(Encryption::Camellia)
-            .cipher_mode(CipherMode::CBC);
-        builder
+fn bench_write_camellia_ctr_archive(c: &mut Criterion) {
+    c.bench_function("write_camellia_ctr_archive", |b| {
+        bench_write_archive(b, {
+            let mut builder = WriteOptions::builder();
+            builder
+                .encryption(Encryption::Camellia)
+                .cipher_mode(CipherMode::CTR);
+            builder
+        });
     });
 }
 
-#[bench]
-fn write_empty_archive(b: &mut Bencher) {
-    b.iter(|| {
-        let mut vec = Vec::with_capacity(1000);
-        let writer = Archive::write_header(&mut vec).expect("failed to write header");
-        writer.finalize().expect("failed to finalize");
-    })
+fn bench_read_camellia_ctr_archive(c: &mut Criterion) {
+    c.bench_function("read_camellia_ctr_archive", |b| {
+        bench_read_archive(b, {
+            let mut builder = WriteOptions::builder();
+            builder
+                .encryption(Encryption::Camellia)
+                .cipher_mode(CipherMode::CTR);
+            builder
+        });
+    });
 }
 
-#[bench]
-fn read_empty_archive(b: &mut Bencher) {
-    let writer = Archive::write_header(Vec::with_capacity(1000)).expect("failed to write header");
-    let vec = writer.finalize().expect("failed to finalize");
-
-    b.iter(|| {
-        let mut reader = Archive::read_header(vec.as_slice()).expect("failed to read header");
-        for entry in reader.entries_skip_solid() {
-            let item = entry.expect("failed to read entry");
-            io::read_to_string(
-                item.reader(ReadOptions::builder().build())
-                    .expect("failed to read entry"),
-            )
-            .expect("failed to make string");
-        }
-    })
+fn bench_write_camellia_cbc_archive(c: &mut Criterion) {
+    c.bench_function("write_camellia_cbc_archive", |b| {
+        bench_write_archive(b, {
+            let mut builder = WriteOptions::builder();
+            builder
+                .encryption(Encryption::Camellia)
+                .cipher_mode(CipherMode::CBC);
+            builder
+        });
+    });
 }
+
+fn bench_read_camellia_cbc_archive(c: &mut Criterion) {
+    c.bench_function("read_camellia_cbc_archive", |b| {
+        bench_read_archive(b, {
+            let mut builder = WriteOptions::builder();
+            builder
+                .encryption(Encryption::Camellia)
+                .cipher_mode(CipherMode::CBC);
+            builder
+        });
+    });
+}
+
+fn bench_write_empty_archive(c: &mut Criterion) {
+    c.bench_function("write_empty_archive", |b| {
+        b.iter(|| {
+            let mut vec = Vec::with_capacity(1000);
+            let writer = Archive::write_header(&mut vec).expect("failed to write header");
+            writer.finalize().expect("failed to finalize");
+        })
+    });
+}
+
+fn bench_read_empty_archive(c: &mut Criterion) {
+    c.bench_function("read_empty_archive", |b| {
+        let writer =
+            Archive::write_header(Vec::with_capacity(1000)).expect("failed to write header");
+        let vec = writer.finalize().expect("failed to finalize");
+
+        b.iter(|| {
+            let mut reader = Archive::read_header(vec.as_slice()).expect("failed to read header");
+            for entry in reader.entries_skip_solid() {
+                let item = entry.expect("failed to read entry");
+                io::read_to_string(
+                    item.reader(ReadOptions::builder().build())
+                        .expect("failed to read entry"),
+                )
+                .expect("failed to make string");
+            }
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_write_store_archive,
+    bench_read_store_archive,
+    bench_read_store_archive_from_slice,
+    bench_write_zstd_archive,
+    bench_read_zstd_archive,
+    bench_read_zstd_archive_from_slice,
+    bench_write_deflate_archive,
+    bench_read_deflate_archive,
+    bench_read_deflate_archive_from_slice,
+    bench_write_xz_archive,
+    bench_read_xz_archive,
+    bench_read_xz_archive_from_slice,
+    bench_write_aes_ctr_archive,
+    bench_read_aes_ctr_archive,
+    bench_write_aes_cbc_archive,
+    bench_read_aes_cbc_archive,
+    bench_write_camellia_ctr_archive,
+    bench_read_camellia_ctr_archive,
+    bench_write_camellia_cbc_archive,
+    bench_read_camellia_cbc_archive,
+    bench_write_empty_archive,
+    bench_read_empty_archive
+);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- use `criterion` for all benchmark code
- register criterion benchmarks in each crate's `Cargo.toml`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: failed to download from `https://index.crates.io/config.json`)*
- `cargo test --all-features` *(fails: failed to download from `https://index.crates.io/config.json`)*