### PR TITLE
Add atime options

### DIFF
--- a/cli/src/command/append.rs
+++ b/cli/src/command/append.rs
@@ -44,6 +44,7 @@ use std::{
     group(ArgGroup::new("group-flag").args(["numeric_owner", "gname"])),
     group(ArgGroup::new("recursive-flag").args(["recursive", "no_recursive"])),
     group(ArgGroup::new("mtime-flag").args(["clamp_mtime"]).requires("mtime")),
+    group(ArgGroup::new("atime-flag").args(["clamp_atime"]).requires("atime")),
 )]
 #[cfg_attr(windows, command(
     group(ArgGroup::new("windows-unstable-keep-permission").args(["keep_permission"]).requires("unstable")),
@@ -115,6 +116,13 @@ pub(crate) struct AppendCommand {
         help = "Clamp the creation time of the entries to the specified time by --ctime"
     )]
     clamp_ctime: bool,
+    #[arg(long, help = "Overrides the access time read from disk")]
+    atime: Option<DateTime>,
+    #[arg(
+        long,
+        help = "Clamp the access time of the entries to the specified time by --atime"
+    )]
+    clamp_atime: bool,
     #[arg(long, help = "Overrides the modification time read from disk")]
     mtime: Option<DateTime>,
     #[arg(
@@ -210,6 +218,8 @@ fn append_to_archive(args: AppendCommand) -> io::Result<()> {
         clamp_mtime: args.clamp_mtime,
         ctime: args.ctime.map(|it| it.to_system_time()),
         clamp_ctime: args.clamp_ctime,
+        atime: args.atime.map(|it| it.to_system_time()),
+        clamp_atime: args.clamp_atime,
     };
     let create_options = CreateOptions {
         option,

--- a/cli/src/command/commons.rs
+++ b/cli/src/command/commons.rs
@@ -111,6 +111,8 @@ pub(crate) struct TimeOptions {
     pub(crate) clamp_mtime: bool,
     pub(crate) ctime: Option<SystemTime>,
     pub(crate) clamp_ctime: bool,
+    pub(crate) atime: Option<SystemTime>,
+    pub(crate) clamp_atime: bool,
 }
 
 pub(crate) fn collect_items(
@@ -297,7 +299,12 @@ pub(crate) fn apply_metadata<'p>(
                     entry.modified(modified_since_unix_epoch);
                 }
             }
-            if let Ok(a) = meta.accessed() {
+            let atime = clamped_time(
+                meta.accessed().ok(),
+                time_options.atime,
+                time_options.clamp_atime,
+            );
+            if let Some(a) = atime {
                 if let Ok(accessed_since_unix_epoch) = a.duration_since(UNIX_EPOCH) {
                     entry.accessed(accessed_since_unix_epoch);
                 }

--- a/cli/src/command/create.rs
+++ b/cli/src/command/create.rs
@@ -48,6 +48,7 @@ use std::{
     group(ArgGroup::new("recursive-flag").args(["recursive", "no_recursive"])),
     group(ArgGroup::new("ctime-flag").args(["clamp_ctime"]).requires("ctime")),
     group(ArgGroup::new("mtime-flag").args(["clamp_mtime"]).requires("mtime")),
+    group(ArgGroup::new("atime-flag").args(["clamp_atime"]).requires("atime")),
 )]
 #[cfg_attr(windows, command(
     group(ArgGroup::new("windows-unstable-keep-permission").args(["keep_permission"]).requires("unstable")),
@@ -129,6 +130,13 @@ pub(crate) struct CreateCommand {
         help = "Clamp the creation time of the entries to the specified time by --ctime"
     )]
     clamp_ctime: bool,
+    #[arg(long, help = "Overrides the access time read from disk")]
+    atime: Option<DateTime>,
+    #[arg(
+        long,
+        help = "Clamp the access time of the entries to the specified time by --atime"
+    )]
+    clamp_atime: bool,
     #[arg(long, help = "Overrides the modification time read from disk")]
     mtime: Option<DateTime>,
     #[arg(
@@ -262,6 +270,8 @@ fn create_archive(args: CreateCommand) -> io::Result<()> {
         clamp_mtime: args.clamp_mtime,
         ctime: args.ctime.map(|it| it.to_system_time()),
         clamp_ctime: args.clamp_ctime,
+        atime: args.atime.map(|it| it.to_system_time()),
+        clamp_atime: args.clamp_atime,
     };
     let password = password.as_deref();
     let write_option = entry_option(args.compression, args.cipher, args.hash, password);

--- a/cli/src/command/stdio.rs
+++ b/cli/src/command/stdio.rs
@@ -43,6 +43,7 @@ use std::{fs, io, path::PathBuf, time::SystemTime};
     group(ArgGroup::new("action-flags").args(["create", "extract", "list", "append"])),
     group(ArgGroup::new("ctime-flag").args(["clamp_ctime"]).requires("ctime")),
     group(ArgGroup::new("mtime-flag").args(["clamp_mtime"]).requires("mtime")),
+    group(ArgGroup::new("atime-flag").args(["clamp_atime"]).requires("atime")),
 )]
 #[cfg_attr(windows, command(
     group(ArgGroup::new("windows-unstable-keep-permission").args(["keep_permission"]).requires("unstable")),
@@ -160,6 +161,13 @@ pub(crate) struct StdioCommand {
         help = "Clamp the creation time of the entries to the specified time by --ctime"
     )]
     clamp_ctime: bool,
+    #[arg(long, help = "Overrides the access time")]
+    atime: Option<DateTime>,
+    #[arg(
+        long,
+        help = "Clamp the access time of the entries to the specified time by --atime"
+    )]
+    clamp_atime: bool,
     #[arg(long, help = "Overrides the modification time")]
     mtime: Option<DateTime>,
     #[arg(
@@ -274,6 +282,8 @@ fn run_create_archive(args: StdioCommand) -> io::Result<()> {
         clamp_mtime: args.clamp_mtime,
         ctime: args.ctime.map(|it| it.to_system_time()),
         clamp_ctime: args.clamp_ctime,
+        atime: args.atime.map(|it| it.to_system_time()),
+        clamp_atime: args.clamp_atime,
     };
     let creation_context = CreationContext {
         write_option: cli_option,
@@ -413,6 +423,8 @@ fn run_append(args: StdioCommand) -> io::Result<()> {
         clamp_mtime: args.clamp_mtime,
         ctime: args.ctime.map(|it| it.to_system_time()),
         clamp_ctime: args.clamp_ctime,
+        atime: args.atime.map(|it| it.to_system_time()),
+        clamp_atime: args.clamp_atime,
     };
     let create_options = CreateOptions {
         option,

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -52,6 +52,7 @@ use std::{
     group(ArgGroup::new("group-flag").args(["numeric_owner", "gname"])),
     group(ArgGroup::new("recursive-flag").args(["recursive", "no_recursive"])),
     group(ArgGroup::new("mtime-flag").args(["clamp_mtime"]).requires("mtime")),
+    group(ArgGroup::new("atime-flag").args(["clamp_atime"]).requires("atime")),
 )]
 #[cfg_attr(windows, command(
     group(ArgGroup::new("windows-unstable-keep-permission").args(["keep_permission"]).requires("unstable")),
@@ -123,6 +124,13 @@ pub(crate) struct UpdateCommand {
         help = "Clamp the creation time of the entries to the specified time by --ctime"
     )]
     clamp_ctime: bool,
+    #[arg(long, help = "Overrides the access time read from disk")]
+    atime: Option<DateTime>,
+    #[arg(
+        long,
+        help = "Clamp the access time of the entries to the specified time by --atime"
+    )]
+    clamp_atime: bool,
     #[arg(
         long,
         help = "Only include files and directories older than the specified date. This compares ctime entries."
@@ -248,6 +256,8 @@ fn update_archive<Strategy: TransformStrategy>(args: UpdateCommand) -> io::Resul
         clamp_mtime: args.clamp_mtime,
         ctime: args.ctime.map(|it| it.to_system_time()),
         clamp_ctime: args.clamp_ctime,
+        atime: args.atime.map(|it| it.to_system_time()),
+        clamp_atime: args.clamp_atime,
     };
     let create_options = CreateOptions {
         option,

--- a/cli/tests/cli/append.rs
+++ b/cli/tests/cli/append.rs
@@ -1,3 +1,4 @@
+mod atime;
 mod ctime;
 mod exclude;
 mod mtime;

--- a/cli/tests/cli/append/atime.rs
+++ b/cli/tests/cli/append/atime.rs
@@ -1,0 +1,153 @@
+use crate::utils::{archive::for_each_entry, setup, TestResources};
+use clap::Parser;
+use portable_network_archive::{cli, command::Command};
+use std::{
+    fs::{self, FileTimes},
+    time::{Duration, SystemTime},
+};
+
+const DURATION_24_HOURS: Duration = Duration::from_secs(24 * 60 * 60);
+
+#[test]
+fn archive_append_with_atime() {
+    setup();
+    TestResources::extract_in("raw/", "archive_append_with_atime/in/").unwrap();
+
+    // Create initial archive
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "archive_append_with_atime/append_with_atime.pna",
+        "--overwrite",
+        "archive_append_with_atime/in/",
+        "--keep-timestamp",
+        "--atime",
+        "2024-01-01T00:00:00Z",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Copy extra input and update their atime
+    TestResources::extract_in("store.pna", "archive_append_with_atime/in/").unwrap();
+    TestResources::extract_in("zstd.pna", "archive_append_with_atime/in/").unwrap();
+
+    let store_file = fs::File::options()
+        .write(true)
+        .open("archive_append_with_atime/in/store.pna")
+        .unwrap();
+    store_file
+        .set_times(FileTimes::new().set_accessed(SystemTime::now() + DURATION_24_HOURS))
+        .unwrap();
+
+    let zstd_file = fs::File::options()
+        .write(true)
+        .open("archive_append_with_atime/in/zstd.pna")
+        .unwrap();
+    zstd_file
+        .set_times(FileTimes::new().set_accessed(SystemTime::now() + DURATION_24_HOURS))
+        .unwrap();
+
+    // Append with specified atime
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "append",
+        "--atime",
+        "2024-01-01T00:00:00Z",
+        "--keep-timestamp",
+        "archive_append_with_atime/append_with_atime.pna",
+        "archive_append_with_atime/in/store.pna",
+        "archive_append_with_atime/in/zstd.pna",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Verify atime is set correctly in the archive
+    let expected = Duration::from_secs(1704067200);
+    for_each_entry(
+        "archive_append_with_atime/append_with_atime.pna",
+        |entry| match entry.header().path().as_str() {
+            "archive_append_with_atime/in/store.pna" | "archive_append_with_atime/in/zstd.pna" => {
+                assert_eq!(entry.metadata().accessed(), Some(expected))
+            }
+            _ => assert!(entry.metadata().accessed().is_some()),
+        },
+    )
+    .unwrap();
+}
+
+#[test]
+fn archive_append_with_clamp_atime() {
+    setup();
+    TestResources::extract_in("raw/", "archive_append_with_clamp_atime/in/").unwrap();
+
+    // Create initial archive
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "archive_append_with_clamp_atime/append_with_clamp_atime.pna",
+        "--overwrite",
+        "archive_append_with_clamp_atime/in/",
+        "--keep-timestamp",
+        "--atime",
+        "2024-01-01T00:00:00Z",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Copy extra input and update their atime
+    TestResources::extract_in("store.pna", "archive_append_with_clamp_atime/in/").unwrap();
+    TestResources::extract_in("zstd.pna", "archive_append_with_clamp_atime/in/").unwrap();
+
+    let store_file = fs::File::options()
+        .write(true)
+        .open("archive_append_with_clamp_atime/in/store.pna")
+        .unwrap();
+    store_file
+        .set_times(FileTimes::new().set_accessed(SystemTime::now() + DURATION_24_HOURS))
+        .unwrap();
+
+    let zstd_file = fs::File::options()
+        .write(true)
+        .open("archive_append_with_clamp_atime/in/zstd.pna")
+        .unwrap();
+    zstd_file
+        .set_times(FileTimes::new().set_accessed(SystemTime::now() + DURATION_24_HOURS))
+        .unwrap();
+
+    // Append with specified atime and clamp
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "append",
+        "--atime",
+        "2024-01-01T00:00:00Z",
+        "--clamp-atime",
+        "--keep-timestamp",
+        "archive_append_with_clamp_atime/append_with_clamp_atime.pna",
+        "archive_append_with_clamp_atime/in/store.pna",
+        "archive_append_with_clamp_atime/in/zstd.pna",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Verify atime is clamped correctly in the archive
+    let expected = Duration::from_secs(1704067200);
+    for_each_entry(
+        "archive_append_with_clamp_atime/append_with_clamp_atime.pna",
+        |entry| match entry.header().path().as_str() {
+            "archive_append_with_clamp_atime/in/store.pna"
+            | "archive_append_with_clamp_atime/in/zstd.pna" => {
+                assert!(entry.metadata().accessed() <= Some(expected))
+            }
+            _ => assert!(entry.metadata().accessed().is_some()),
+        },
+    )
+    .unwrap();
+}

--- a/cli/tests/cli/create.rs
+++ b/cli/tests/cli/create.rs
@@ -1,3 +1,4 @@
+mod atime;
 mod ctime;
 mod exclude;
 mod exclude_from;

--- a/cli/tests/cli/create/atime.rs
+++ b/cli/tests/cli/create/atime.rs
@@ -1,0 +1,92 @@
+use crate::utils::{archive::for_each_entry, setup, TestResources};
+use clap::Parser;
+use portable_network_archive::{cli, command::Command};
+use std::{
+    fs::{self, FileTimes},
+    io::prelude::*,
+    time::{Duration, SystemTime},
+};
+
+const DURATION_24_HOURS: Duration = Duration::from_secs(24 * 60 * 60);
+
+#[test]
+fn archive_create_with_atime() {
+    setup();
+    TestResources::extract_in("raw/", "archive_create_with_atime/in/").unwrap();
+
+    // Update file with newer atime
+    let mut file = fs::File::options()
+        .write(true)
+        .truncate(true)
+        .open("archive_create_with_atime/in/raw/text.txt")
+        .unwrap();
+    file.write_all(b"updated!").unwrap();
+    file.set_times(FileTimes::new().set_accessed(SystemTime::now() + DURATION_24_HOURS))
+        .unwrap();
+
+    // Create archive with specified atime
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "archive_create_with_atime/create_with_atime.pna",
+        "--overwrite",
+        "archive_create_with_atime/in/",
+        "--keep-timestamp",
+        "--atime",
+        "2024-01-01T00:00:00Z",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Verify atime is set correctly in the archive
+    let expected = Duration::from_secs(1704067200);
+    for_each_entry("archive_create_with_atime/create_with_atime.pna", |entry| {
+        assert_eq!(entry.metadata().accessed(), Some(expected));
+    })
+    .unwrap();
+}
+
+#[test]
+fn archive_create_with_clamp_atime() {
+    setup();
+    TestResources::extract_in("raw/", "archive_create_with_clamp_atime/in/").unwrap();
+
+    // Update file with newer atime
+    let mut file = fs::File::options()
+        .write(true)
+        .truncate(true)
+        .open("archive_create_with_clamp_atime/in/raw/text.txt")
+        .unwrap();
+    file.write_all(b"updated!").unwrap();
+    file.set_times(FileTimes::new().set_accessed(SystemTime::now() + DURATION_24_HOURS))
+        .unwrap();
+
+    // Create archive with specified atime and clamp
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "archive_create_with_clamp_atime/create_with_clamp_atime.pna",
+        "--overwrite",
+        "archive_create_with_clamp_atime/in/",
+        "--keep-timestamp",
+        "--atime",
+        "2024-01-01T00:00:00Z",
+        "--clamp-atime",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Verify atime is clamped correctly in the archive
+    let expected = Duration::from_secs(1704067200);
+    for_each_entry(
+        "archive_create_with_clamp_atime/create_with_clamp_atime.pna",
+        |entry| {
+            assert!(entry.metadata().accessed() <= Some(expected));
+        },
+    )
+    .unwrap();
+}

--- a/cli/tests/cli/update.rs
+++ b/cli/tests/cli/update.rs
@@ -1,3 +1,4 @@
+mod atime;
 mod ctime;
 mod exclude;
 mod mtime;

--- a/cli/tests/cli/update/atime.rs
+++ b/cli/tests/cli/update/atime.rs
@@ -1,0 +1,118 @@
+use crate::utils::{archive::for_each_entry, setup, TestResources};
+use clap::Parser;
+use portable_network_archive::{cli, command::Command};
+use std::{
+    fs::{self, FileTimes},
+    io::prelude::*,
+    time::{Duration, SystemTime},
+};
+
+const DURATION_24_HOURS: Duration = Duration::from_secs(24 * 60 * 60);
+
+#[test]
+fn archive_update_with_atime() {
+    setup();
+    TestResources::extract_in("raw/", "archive_update_with_atime/in/").unwrap();
+    // Create initial archive
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "archive_update_with_atime/update_with_atime.pna",
+        "--overwrite",
+        "archive_update_with_atime/in/",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Update file with newer atime
+    let mut file = fs::File::options()
+        .write(true)
+        .truncate(true)
+        .open("archive_update_with_atime/in/raw/text.txt")
+        .unwrap();
+    file.write_all(b"updated!").unwrap();
+    file.set_times(FileTimes::new().set_accessed(SystemTime::now() + DURATION_24_HOURS))
+        .unwrap();
+
+    // Update archive with specified atime
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "--atime",
+        "2024-01-01T00:00:00Z",
+        "archive_update_with_atime/update_with_atime.pna",
+        "archive_update_with_atime/in/",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Verify atime is set correctly in the archive
+    let expected = Duration::from_secs(1704067200);
+    for_each_entry("archive_update_with_atime/update_with_atime.pna", |entry| {
+        assert_eq!(entry.metadata().accessed(), Some(expected));
+    })
+    .unwrap();
+}
+
+#[test]
+fn archive_update_with_clamp_atime() {
+    setup();
+    TestResources::extract_in("raw/", "archive_update_with_clamp_atime/in/").unwrap();
+    // Create initial archive
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "archive_update_with_clamp_atime/update_with_clamp_atime.pna",
+        "--overwrite",
+        "archive_update_with_clamp_atime/in/",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Update file with newer atime
+    let mut file = fs::File::options()
+        .write(true)
+        .truncate(true)
+        .open("archive_update_with_clamp_atime/in/raw/text.txt")
+        .unwrap();
+    file.write_all(b"updated!").unwrap();
+    file.set_times(FileTimes::new().set_accessed(SystemTime::now() + DURATION_24_HOURS))
+        .unwrap();
+
+    // Update archive with specified atime and clamp
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "--atime",
+        "2024-01-01T00:00:00Z",
+        "--clamp-atime",
+        "archive_update_with_clamp_atime/update_with_clamp_atime.pna",
+        "archive_update_with_clamp_atime/in/",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Verify atime is clamped correctly in the archive
+    let expected = Duration::from_secs(1704067200);
+    for_each_entry(
+        "archive_update_with_clamp_atime/update_with_clamp_atime.pna",
+        |entry| {
+            assert!(entry.metadata().accessed() <= Some(expected));
+        },
+    )
+    .unwrap();
+}


### PR DESCRIPTION
## Summary
- add `--atime` and `--clamp-atime` handling in CLI
- support access time when applying metadata
- extend test suite with create, append and update scenarios for atime

## Testing
- `cargo clippy --workspace --all-features -- -D warnings`
- `cargo test --quiet`
