### PR TITLE
Add experimental diff command

### DIFF
--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -9,6 +9,7 @@ pub mod complete;
 pub(crate) mod concat;
 pub mod create;
 mod delete;
+pub mod diff;
 pub(super) mod experimental;
 pub mod extract;
 pub mod list;

--- a/cli/src/command/diff.rs
+++ b/cli/src/command/diff.rs
@@ -1,0 +1,86 @@
+use crate::{
+    cli::{FileArgs, PasswordArgs},
+    command::{
+        ask_password,
+        commons::{collect_split_archives, run_process_archive},
+        Command,
+    },
+};
+use clap::Parser;
+use pna::{DataKind, NormalEntry, ReadOptions};
+use std::{
+    fs,
+    io::{self, Read},
+    path::PathBuf,
+};
+
+#[derive(Parser, Clone, Debug)]
+pub(crate) struct DiffCommand {
+    #[command(flatten)]
+    pub(crate) file: FileArgs,
+    #[command(flatten)]
+    pub(crate) password: PasswordArgs,
+}
+
+impl Command for DiffCommand {
+    #[inline]
+    fn execute(self) -> io::Result<()> {
+        diff_archive(self)
+    }
+}
+
+fn diff_archive(args: DiffCommand) -> io::Result<()> {
+    let password = ask_password(args.password)?;
+    let archives = collect_split_archives(&args.file.archive)?;
+    run_process_archive(
+        archives,
+        || password.as_deref(),
+        |entry| {
+            let entry = entry?;
+            compare_entry(entry, password.as_deref())
+        },
+    )
+}
+
+fn compare_entry<T: AsRef<[u8]>>(entry: NormalEntry<T>, password: Option<&str>) -> io::Result<()> {
+    let path = PathBuf::from(entry.header().path().as_path());
+    match entry.header().data_kind() {
+        DataKind::File => match fs::read(&path) {
+            Ok(data) => {
+                let mut reader = entry.reader(ReadOptions::with_password(password))?;
+                let mut buf = Vec::new();
+                reader.read_to_end(&mut buf)?;
+                if buf != data {
+                    println!("Different file content: {}", path.display());
+                }
+            }
+            Err(_) => {
+                println!("Missing file: {}", path.display());
+            }
+        },
+        DataKind::Directory => {
+            if !path.is_dir() {
+                println!("Missing directory: {}", path.display());
+            }
+        }
+        DataKind::SymbolicLink => match fs::read_link(&path) {
+            Ok(link) => {
+                let mut reader = entry.reader(ReadOptions::with_password(password))?;
+                let mut link_str = String::new();
+                reader.read_to_string(&mut link_str)?;
+                if link != PathBuf::from(link_str) {
+                    println!("Different symlink: {}", path.display());
+                }
+            }
+            Err(_) => {
+                println!("Missing symlink: {}", path.display());
+            }
+        },
+        DataKind::HardLink => {
+            if !path.exists() {
+                println!("Missing hardlink: {}", path.display());
+            }
+        }
+    }
+    Ok(())
+}

--- a/cli/src/command/experimental.rs
+++ b/cli/src/command/experimental.rs
@@ -1,3 +1,4 @@
+use crate::command::diff::DiffCommand;
 use crate::{command, command::Command};
 use clap::{Parser, Subcommand};
 use std::io;
@@ -32,6 +33,7 @@ impl Command for ExperimentalCommand {
             ExperimentalCommands::Acl(cmd) => cmd.execute(),
             ExperimentalCommands::Migrate(cmd) => cmd.execute(),
             ExperimentalCommands::Chunk(cmd) => cmd.execute(),
+            ExperimentalCommands::Diff(cmd) => cmd.execute(),
         }
     }
 }
@@ -56,4 +58,6 @@ pub(crate) enum ExperimentalCommands {
     Migrate(command::migrate::MigrateCommand),
     #[command(about = "Chunk level operation")]
     Chunk(command::chunk::ChunkCommand),
+    #[command(about = "Compare archive entries with file system")]
+    Diff(DiffCommand),
 }

--- a/cli/tests/cli/diff.rs
+++ b/cli/tests/cli/diff.rs
@@ -1,0 +1,25 @@
+use crate::utils::{setup, TestResources};
+use clap::Parser;
+use portable_network_archive::{cli, command::Command};
+
+#[test]
+fn experimental_diff() {
+    setup();
+    TestResources::extract_in("raw/", "diff/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "diff/diff.pna",
+        "--overwrite",
+        "diff/in/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    cli::Cli::try_parse_from(["pna", "experimental", "diff", "diff/diff.pna"])
+        .unwrap()
+        .execute()
+        .unwrap();
+}

--- a/cli/tests/cli/main.rs
+++ b/cli/tests/cli/main.rs
@@ -10,6 +10,7 @@ mod combination;
 mod concat;
 mod create;
 mod delete;
+mod diff;
 mod encrypt;
 mod extract;
 mod hardlink;


### PR DESCRIPTION
## Summary
- move diff command under the `experimental` subcommand
- add tests for the new `experimental diff` command

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
