### PR TITLE
Refactor memmap handling

### DIFF
--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -380,8 +380,13 @@ pub(crate) fn run_list_archive_mem(
     args: ListOptions,
 ) -> io::Result<()> {
     let mut entries = Vec::new();
+    let archives = archives
+        .into_iter()
+        .map(crate::utils::mmap::Mmap::try_from)
+        .collect::<io::Result<Vec<_>>>()?;
+    let archive_slices = archives.iter().map(|m| m.as_ref()).collect::<Vec<_>>();
 
-    run_read_entries_mem(archives, |entry| {
+    run_read_entries_mem(archive_slices, |entry| {
         match entry? {
             ReadEntry::Solid(solid) if args.solid => {
                 for entry in solid.entries(password)? {

--- a/cli/tests/cli/update/files_from_stdin.rs
+++ b/cli/tests/cli/update/files_from_stdin.rs
@@ -12,7 +12,7 @@ fn test_update_files_from_stdin() {
     // Create a base archive
     Command::cargo_bin("pna")
         .unwrap()
-        .args(&[
+        .args([
             "--quiet",
             "create",
             "update_files_from_stdin/base.pna",
@@ -28,7 +28,7 @@ fn test_update_files_from_stdin() {
 
     // Run update command with --files-from-stdin
     let mut cmd = Command::cargo_bin("pna").unwrap();
-    cmd.args(&[
+    cmd.args([
         "--quiet",
         "experimental",
         "update",
@@ -43,7 +43,7 @@ fn test_update_files_from_stdin() {
     // Extract the updated archive and verify contents
     Command::cargo_bin("pna")
         .unwrap()
-        .args(&[
+        .args([
             "--quiet",
             "extract",
             "update_files_from_stdin/base.pna",


### PR DESCRIPTION
## Summary
- refactor `run_read_entries_mem` to accept slice references
- map mmaps in `run_entries` and `run_transform_entry`
- map mmaps for `run_list_archive_mem` and update command

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`


------
https://chatgpt.com/codex/tasks/task_b_684f636189208325ba9cad7d8f85d201