### PR TITLE
Enhance CLI error tracing

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -6,6 +6,7 @@ use crate::command::{
     extract::ExtractCommand, list::ListCommand, split::SplitCommand, strip::StripCommand,
     xattr::XattrCommand,
 };
+use anyhow::Context;
 use clap::{value_parser, ArgGroup, Parser, Subcommand, ValueEnum, ValueHint};
 use log::{Level, LevelFilter};
 use pna::HashAlgorithm;
@@ -41,7 +42,9 @@ impl Cli {
                 Level::Info | Level::Debug | Level::Trace => out.finish(*msg),
             })
             .chain(io::stderr());
-        base.chain(stderr).apply()?;
+        base.chain(stderr)
+            .apply()
+            .with_context(|| "failed to initialize logger")?;
         Ok(())
     }
 }

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -20,11 +20,14 @@ pub mod update;
 pub mod xattr;
 
 use crate::cli::{CipherAlgorithmArgs, Cli, Commands, PasswordArgs};
+use anyhow::Context;
 use std::fs;
 
 fn ask_password(args: PasswordArgs) -> anyhow::Result<Option<String>> {
     if let Some(path) = args.password_file {
-        return Ok(Some(fs::read_to_string(path)?));
+        return Ok(Some(fs::read_to_string(&path).with_context(|| {
+            format!("failed to read password file {}", path.display())
+        })?));
     };
     Ok(match args.password {
         Some(password @ Some(_)) => {

--- a/cli/src/command/append.rs
+++ b/cli/src/command/append.rs
@@ -263,7 +263,7 @@ fn append_to_archive(args: AppendCommand) -> anyhow::Result<()> {
     )?;
 
     run_append_archive(&create_options, &path_transformers, archive, target_items)
-        .with_context(|| "")
+        .with_context(|| "failed to append files to archive")
 }
 
 pub(crate) fn run_append_archive(

--- a/cli/src/command/commons.rs
+++ b/cli/src/command/commons.rs
@@ -151,7 +151,7 @@ pub(crate) fn collect_items(
                 Err(e) => Some(Err(e)),
             })
             .collect::<Result<Vec<_>, _>>()
-            .with_context(|| "")
+            .with_context(|| "failed to collect input files")
     } else {
         Ok(Vec::new())
     }
@@ -202,7 +202,7 @@ pub(crate) fn create_entry(
             fs::symlink_metadata,
         )?
         .build()
-        .with_context(|| "");
+        .with_context(|| format!("failed to build symlink entry for {}", path.display()));
     } else if path.is_file() {
         let mut entry = EntryBuilder::new_file(entry_name, option)?;
         #[cfg(feature = "memmap")]
@@ -229,7 +229,7 @@ pub(crate) fn create_entry(
             fs::metadata,
         )?
         .build()
-        .with_context(|| "");
+        .with_context(|| format!("failed to build file entry for {}", path.display()));
     } else if path.is_dir() {
         let entry = EntryBuilder::new_dir(EntryName::from_lossy(path));
         return apply_metadata(
@@ -241,13 +241,13 @@ pub(crate) fn create_entry(
             fs::metadata,
         )?
         .build()
-        .with_context(|| "");
+        .with_context(|| format!("failed to build directory entry for {}", path.display()));
     }
     Err(io::Error::new(
         io::ErrorKind::Unsupported,
         "Currently not a regular file is not supported.",
     ))
-    .with_context(|| "")
+    .with_context(|| format!("unsupported file type: {}", path.display()))
 }
 
 pub(crate) fn entry_option(

--- a/cli/src/command/concat.rs
+++ b/cli/src/command/concat.rs
@@ -33,7 +33,12 @@ fn concat_entry(args: ConcatCommand) -> anyhow::Result<()> {
             io::ErrorKind::AlreadyExists,
             format!("{} already exists", args.files.archive.display()),
         ))
-        .with_context(|| "");
+        .with_context(|| {
+            format!(
+                "output archive {} already exists",
+                args.files.archive.display()
+            )
+        });
     }
     for item in &args.files.files {
         if !utils::fs::is_pna(item)? {
@@ -41,7 +46,7 @@ fn concat_entry(args: ConcatCommand) -> anyhow::Result<()> {
                 io::ErrorKind::InvalidData,
                 format!("{item} is not a pna file"),
             ))
-            .with_context(|| "");
+            .with_context(|| format!("{} is not a valid pna archive", item));
         }
     }
     let file = utils::fs::file_create(&args.files.archive, args.overwrite)?;

--- a/cli/src/command/create.rs
+++ b/cli/src/command/create.rs
@@ -17,6 +17,7 @@ use crate::{
         re::{bsd::SubstitutionRule, gnu::TransformRule},
     },
 };
+use anyhow::Context;
 use bytesize::ByteSize;
 use clap::{ArgGroup, Parser, ValueHint};
 use pna::{Archive, SolidEntryBuilder, WriteOptions};
@@ -212,7 +213,8 @@ fn create_archive(args: CreateCommand) -> anyhow::Result<()> {
         return Err(io::Error::new(
             io::ErrorKind::AlreadyExists,
             format!("{} already exists", archive.display()),
-        ))?;
+        ))
+        .with_context(|| "archive already exists");
     }
     log::info!("Create an archive: {}", archive.display());
     let mut files = args.file.files;

--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -292,12 +292,12 @@ fn list_archive(args: ListCommand) -> anyhow::Result<()> {
             exclude,
             options,
         )
-        .with_context(|| "")
+        .with_context(|| "failed to list archive contents")
     }
     #[cfg(feature = "memmap")]
     {
         run_list_archive_mem(archives, password.as_deref(), files_globs, exclude, options)
-            .with_context(|| "")
+            .with_context(|| "failed to list archive contents")
     }
 }
 

--- a/cli/src/command/stdio.rs
+++ b/cli/src/command/stdio.rs
@@ -230,7 +230,7 @@ fn run_stdio(args: StdioCommand) -> anyhow::Result<()> {
     } else if args.list {
         run_list_archive(args)
     } else if args.append {
-        run_append(args).with_context(|| "")
+        run_append(args).with_context(|| "failed to append using stdio mode")
     } else {
         unreachable!()
     }
@@ -493,6 +493,6 @@ fn run_append(args: StdioCommand) -> anyhow::Result<()> {
             output_archive,
             target_items,
         )
-        .with_context(|| "")
+        .with_context(|| "failed to append archive from stdio")
     }
 }

--- a/cli/src/command/strip.rs
+++ b/cli/src/command/strip.rs
@@ -91,7 +91,7 @@ fn strip_metadata(args: StripCommand) -> anyhow::Result<()> {
             TransformStrategyKeepSolid,
         ),
     }
-    .with_context(|| "")
+    .with_context(|| "failed to strip archive")
 }
 
 #[inline]

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -236,7 +236,8 @@ fn update_archive<Strategy: TransformStrategy>(args: UpdateCommand) -> anyhow::R
         return Err(io::Error::new(
             io::ErrorKind::NotFound,
             format!("{} is not exists", archive_path.display()),
-        ))?;
+        ))
+        .with_context(|| "archive not found");
     }
     let password = password.as_deref();
     let option = entry_option(args.compression, args.cipher, args.hash, password);
@@ -392,7 +393,7 @@ fn update_archive<Strategy: TransformStrategy>(args: UpdateCommand) -> anyhow::R
     for entry in rx.into_iter() {
         Strategy::transform(
             &mut out_archive,
-            password.as_deref(),
+            password,
             entry.map(Into::into).map_err(io::Error::other),
             |entry| entry.map(Some),
         )?;


### PR DESCRIPTION
## Summary
- improve password file reading error context
- add detailed `anyhow` contexts when building entries and processing archives
- refine concat archive validations
- report logger initialization failures clearly

## Testing
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_b_68522bffb9648325a60adb4dcf2272d5