### PR TITLE
Improve error context using anyhow

### DIFF
--- a/cli/src/utils/io.rs
+++ b/cli/src/utils/io.rs
@@ -1,7 +1,10 @@
+use anyhow::Context;
 use std::io;
 
-pub(crate) fn is_pna<R: io::Read>(mut reader: R) -> io::Result<bool> {
+pub(crate) fn is_pna<R: io::Read>(mut reader: R) -> anyhow::Result<bool> {
     let mut buf = [0u8; pna::PNA_HEADER.len()];
-    reader.read_exact(&mut buf)?;
+    reader
+        .read_exact(&mut buf)
+        .with_context(|| "failed to read archive header")?;
     Ok(buf == *pna::PNA_HEADER)
 }


### PR DESCRIPTION
## Summary
- add context when reading PNA headers
- add context on archive file access and reading lines
- improve split archive writer errors

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_b_68524c37a16c832582ad771f19961a39