### PR TITLE
Add experimental sort command

### DIFF
--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -13,6 +13,7 @@ pub(super) mod experimental;
 pub mod extract;
 pub mod list;
 mod migrate;
+mod sort;
 pub mod split;
 pub(crate) mod stdio;
 pub(crate) mod strip;

--- a/cli/src/command/experimental.rs
+++ b/cli/src/command/experimental.rs
@@ -32,6 +32,7 @@ impl Command for ExperimentalCommand {
             ExperimentalCommands::Acl(cmd) => cmd.execute(),
             ExperimentalCommands::Migrate(cmd) => cmd.execute(),
             ExperimentalCommands::Chunk(cmd) => cmd.execute(),
+            ExperimentalCommands::Sort(cmd) => cmd.execute(),
         }
     }
 }
@@ -56,4 +57,6 @@ pub(crate) enum ExperimentalCommands {
     Migrate(command::migrate::MigrateCommand),
     #[command(about = "Chunk level operation")]
     Chunk(command::chunk::ChunkCommand),
+    #[command(about = "Sort entries in archive")]
+    Sort(command::sort::SortCommand),
 }

--- a/cli/src/command/sort.rs
+++ b/cli/src/command/sort.rs
@@ -1,0 +1,74 @@
+use crate::{
+    cli::PasswordArgs,
+    command::{
+        ask_password,
+        commons::{collect_split_archives, run_entries},
+        Command,
+    },
+    utils::PathPartExt,
+};
+use clap::{Parser, ValueEnum, ValueHint};
+use pna::{Archive, NormalEntry};
+use std::{fs, io, path::PathBuf};
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, ValueEnum)]
+pub(crate) enum SortBy {
+    Name,
+    Ctime,
+    Mtime,
+    Atime,
+}
+
+#[derive(Parser, Clone, Eq, PartialEq, Hash, Debug)]
+pub(crate) struct SortCommand {
+    #[arg(value_hint = ValueHint::FilePath)]
+    archive: PathBuf,
+    #[arg(long, help = "Output file path", value_hint = ValueHint::FilePath)]
+    output: Option<PathBuf>,
+    #[arg(long = "by", value_enum, num_args = 1.., default_values_t = [SortBy::Name])]
+    by: Vec<SortBy>,
+    #[command(flatten)]
+    password: PasswordArgs,
+}
+
+impl Command for SortCommand {
+    #[inline]
+    fn execute(self) -> io::Result<()> {
+        sort_archive(self)
+    }
+}
+
+fn sort_archive(args: SortCommand) -> io::Result<()> {
+    let password = ask_password(args.password)?;
+    let archives = collect_split_archives(&args.archive)?;
+    let mut entries = Vec::<NormalEntry<Vec<u8>>>::new();
+    run_entries(
+        archives,
+        || password.as_deref(),
+        |entry| {
+            #[allow(clippy::useless_conversion)]
+            {
+                entries.push(entry?.into());
+            }
+            Ok(())
+        },
+    )?;
+
+    for by in args.by.iter().rev() {
+        match by {
+            SortBy::Name => entries.sort_by(|a, b| a.header().path().cmp(b.header().path())),
+            SortBy::Ctime | SortBy::Mtime | SortBy::Atime => todo!(),
+        }
+    }
+
+    let output = args
+        .output
+        .unwrap_or_else(|| args.archive.remove_part().unwrap());
+    let outfile = fs::File::create(&output)?;
+    let mut archive = Archive::write_header(outfile)?;
+    for entry in entries {
+        archive.add_entry(entry)?;
+    }
+    archive.finalize()?;
+    Ok(())
+}

--- a/cli/tests/cli/main.rs
+++ b/cli/tests/cli/main.rs
@@ -20,6 +20,7 @@ mod multipart;
 mod restore_acl;
 mod restore_acl_0_19_1;
 mod solid_mode;
+mod sort;
 mod split;
 mod strip;
 mod update;

--- a/cli/tests/cli/sort.rs
+++ b/cli/tests/cli/sort.rs
@@ -1,0 +1,36 @@
+use crate::utils::{archive::for_each_entry, setup};
+use clap::Parser;
+use pna::{Archive, EntryBuilder, WriteOptions};
+use portable_network_archive::{cli, command::Command};
+use std::fs;
+
+#[test]
+fn sort_by_name() {
+    setup();
+    fs::create_dir_all("sort_by_name").unwrap();
+    let file = fs::File::create("sort_by_name/unsorted.pna").unwrap();
+    let mut archive = Archive::write_header(file).unwrap();
+    let entry_b = EntryBuilder::new_file("b.txt".into(), WriteOptions::store()).unwrap();
+    archive.add_entry(entry_b.build().unwrap()).unwrap();
+    let entry_a = EntryBuilder::new_file("a.txt".into(), WriteOptions::store()).unwrap();
+    archive.add_entry(entry_a.build().unwrap()).unwrap();
+    archive.finalize().unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "sort",
+        "sort_by_name/unsorted.pna",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut names = Vec::new();
+    for_each_entry("sort_by_name/unsorted.pna", |e| {
+        names.push(e.header().path().as_str().to_string());
+    })
+    .unwrap();
+    assert_eq!(names, ["a.txt", "b.txt"]);
+}


### PR DESCRIPTION
## Summary
- add `sort` subcommand under `experimental`
- allow sorting archive entries by name with placeholder for timestamp sorting
- test sorting behaviour

## Testing
- `cargo clippy --tests -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_685822ab68788325867c0c7be0872886