### PR TITLE
Add working directory option to stdio

### DIFF
--- a/cli/tests/cli/cd_option.rs
+++ b/cli/tests/cli/cd_option.rs
@@ -140,3 +140,38 @@ fn update_with_cd() {
     // check completely extracted
     diff("update_with_cd/in/", "update_with_cd/out/").unwrap();
 }
+
+#[test]
+fn stdio_with_cd() {
+    setup();
+    TestResources::extract_in("raw/", "stdio_with_cd/in/").unwrap();
+
+    let mut cmd = assert_cmd::Command::cargo_bin("pna").unwrap();
+    cmd.args([
+        "--quiet",
+        "experimental",
+        "stdio",
+        "-c",
+        "-C",
+        "stdio_with_cd/in/",
+        ".",
+    ]);
+    let assert = cmd.assert().success();
+
+    let mut cmd = assert_cmd::Command::cargo_bin("pna").unwrap();
+    cmd.write_stdin(assert.get_output().stdout.as_slice());
+    cmd.args([
+        "--quiet",
+        "experimental",
+        "stdio",
+        "-x",
+        "--overwrite",
+        "-C",
+        ".",
+        "--out-dir",
+        "stdio_with_cd/out/",
+    ]);
+    cmd.assert().success();
+
+    diff("stdio_with_cd/in/", "stdio_with_cd/out/").unwrap();
+}


### PR DESCRIPTION
## Summary
- add `--working-dir` support to the `stdio` command
- test stdio with the new working directory option

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --all-features`

------
https://chatgpt.com/codex/tasks/task_b_6865e78d45008325801c5906d682ff42