### PR TITLE
Add -H option to follow symlinks on command line

### DIFF
--- a/cli/src/command/append.rs
+++ b/cli/src/command/append.rs
@@ -162,6 +162,12 @@ pub(crate) struct AppendCommand {
     #[arg(long, visible_aliases = ["dereference"], help = "Follow symbolic links")]
     follow_links: bool,
     #[arg(
+        short = 'H',
+        long,
+        help = "Follow symbolic links named on the command line"
+    )]
+    follow_command_links: bool,
+    #[arg(
         long,
         help = "Filenames or patterns are separated by null characters, not by newlines"
     )]
@@ -280,6 +286,7 @@ fn append_to_archive(args: AppendCommand) -> anyhow::Result<()> {
         args.keep_dir,
         args.gitignore,
         args.follow_links,
+        args.follow_command_links,
         exclude,
     )?;
 
@@ -290,7 +297,7 @@ pub(crate) fn run_append_archive(
     create_options: &CreateOptions,
     path_transformers: &Option<PathTransformers>,
     mut archive: Archive<impl io::Write>,
-    target_items: Vec<(PathBuf, Option<PathBuf>)>,
+    target_items: Vec<(PathBuf, Option<PathBuf>, bool)>,
 ) -> anyhow::Result<()> {
     let (tx, rx) = std::sync::mpsc::channel();
     rayon::scope_fifo(|s| {

--- a/cli/src/command/commons.rs
+++ b/cli/src/command/commons.rs
@@ -121,16 +121,26 @@ pub(crate) fn collect_items(
     keep_dir: bool,
     gitignore: bool,
     follow_links: bool,
+    follow_command_links: bool,
     exclude: Exclude,
-) -> io::Result<Vec<(PathBuf, Option<PathBuf>)>> {
-    let mut files = files.into_iter();
-    if let Some(p) = files.next() {
-        let mut hardlink_resolver = HardlinkResolver::new(follow_links);
-        let mut builder = ignore::WalkBuilder::new(p);
-        for p in files {
-            builder.add(p);
-        }
-        builder.filter_entry(move |e| !exclude.excluded(e.path().to_slash_lossy()));
+) -> io::Result<Vec<(PathBuf, Option<PathBuf>, bool)>> {
+    let mut files = files.into_iter().peekable();
+    if files.peek().is_none() {
+        return Ok(Vec::new());
+    }
+
+    let mut hardlink_resolver = HardlinkResolver::new(follow_links || follow_command_links);
+    let mut results = Vec::new();
+
+    for file in files {
+        let path = file.as_ref();
+        let is_symlink = fs::symlink_metadata(path)
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(false);
+        let follow_root = follow_links || (follow_command_links && is_symlink);
+
+        let mut builder = ignore::WalkBuilder::new(path);
+        let exclude = exclude.clone();
         builder
             .max_depth(if recursive { None } else { Some(0) })
             .hidden(false)
@@ -139,37 +149,38 @@ pub(crate) fn collect_items(
             .git_exclude(false)
             .git_global(false)
             .parents(false)
-            .follow_links(follow_links)
+            .follow_links(follow_root)
             .ignore_case_insensitive(false)
-            .sort_by_file_path(Path::cmp);
-        let walker = builder.build();
-        walker
-            .filter_map(|path| match path {
-                Ok(path) => {
-                    let file_type = path.file_type();
-                    match file_type {
-                        None => None,
-                        Some(ty) => {
-                            if !keep_dir && ty.is_dir() {
-                                return None;
-                            }
-                            let path = path.into_path();
-                            let linked = if ty.is_file() {
-                                hardlink_resolver.resolve(&path).ok().flatten()
-                            } else {
-                                None
-                            };
-                            Some(Ok((path, linked)))
+            .sort_by_file_path(Path::cmp)
+            .filter_entry(move |e| !exclude.excluded(e.path().to_slash_lossy()));
+
+        for entry in builder.build() {
+            match entry {
+                Ok(entry) => {
+                    if let Some(ty) = entry.file_type() {
+                        if !keep_dir && ty.is_dir() {
+                            continue;
                         }
+                        let entry_path = entry.into_path();
+                        let linked = if ty.is_file() {
+                            hardlink_resolver.resolve(&entry_path).ok().flatten()
+                        } else {
+                            None
+                        };
+                        let follow = if follow_links {
+                            true
+                        } else {
+                            follow_root && entry_path == path
+                        };
+                        results.push((entry_path, linked, follow));
                     }
                 }
-                Err(e) => Some(Err(e)),
-            })
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(io::Error::other)
-    } else {
-        Ok(Vec::new())
+                Err(e) => return Err(io::Error::other(e)),
+            }
+        }
     }
+
+    Ok(results)
 }
 
 pub(crate) fn collect_split_archives(first: impl AsRef<Path>) -> io::Result<Vec<fs::File>> {
@@ -209,7 +220,7 @@ pub(crate) fn write_from_path(writer: &mut impl Write, path: impl AsRef<Path>) -
 }
 
 pub(crate) fn create_entry(
-    (path, link): &(PathBuf, Option<PathBuf>),
+    (path, link, follow_item): &(PathBuf, Option<PathBuf>, bool),
     CreateOptions {
         option,
         keep_options,
@@ -240,7 +251,7 @@ pub(crate) fn create_entry(
             fs::symlink_metadata,
         )?
         .build();
-    } else if !follow_links && path.is_symlink() {
+    } else if !(*follow_links || *follow_item) && path.is_symlink() {
         let source = fs::read_link(path)?;
         let reference = if let Some(substitutions) = substitutions {
             EntryReference::from(substitutions.apply(source.to_string_lossy(), true, false))
@@ -932,9 +943,13 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
             "/../resources/test/raw",
         )];
-        let items = collect_items(source, false, false, false, false, empty_exclude()).unwrap();
+        let items =
+            collect_items(source, false, false, false, false, false, empty_exclude()).unwrap();
         assert_eq!(
-            items.into_iter().map(|(it, _)| it).collect::<HashSet<_>>(),
+            items
+                .into_iter()
+                .map(|(it, _, _)| it)
+                .collect::<HashSet<_>>(),
             HashSet::new()
         );
     }
@@ -945,9 +960,13 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
             "/../resources/test/raw",
         )];
-        let items = collect_items(source, false, true, false, false, empty_exclude()).unwrap();
+        let items =
+            collect_items(source, false, true, false, false, false, empty_exclude()).unwrap();
         assert_eq!(
-            items.into_iter().map(|(it, _)| it).collect::<HashSet<_>>(),
+            items
+                .into_iter()
+                .map(|(it, _, _)| it)
+                .collect::<HashSet<_>>(),
             [concat!(
                 env!("CARGO_MANIFEST_DIR"),
                 "/../resources/test/raw",
@@ -964,9 +983,13 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
             "/../resources/test/raw",
         )];
-        let items = collect_items(source, true, false, false, false, empty_exclude()).unwrap();
+        let items =
+            collect_items(source, true, false, false, false, false, empty_exclude()).unwrap();
         assert_eq!(
-            items.into_iter().map(|(it, _)| it).collect::<HashSet<_>>(),
+            items
+                .into_iter()
+                .map(|(it, _, _)| it)
+                .collect::<HashSet<_>>(),
             [
                 concat!(
                     env!("CARGO_MANIFEST_DIR"),

--- a/cli/src/command/create.rs
+++ b/cli/src/command/create.rs
@@ -179,6 +179,12 @@ pub(crate) struct CreateCommand {
     #[arg(long, visible_aliases = ["dereference"], help = "Follow symbolic links")]
     follow_links: bool,
     #[arg(
+        short = 'H',
+        long,
+        help = "Follow symbolic links named on the command line"
+    )]
+    follow_command_links: bool,
+    #[arg(
         long,
         help = "Filenames or patterns are separated by null characters, not by newlines"
     )]
@@ -267,6 +273,7 @@ fn create_archive(args: CreateCommand) -> anyhow::Result<()> {
         args.keep_dir,
         args.gitignore,
         args.follow_links,
+        args.follow_command_links,
         exclude,
     )?;
 
@@ -353,7 +360,7 @@ pub(crate) fn create_archive_file<W, F>(
         follow_links,
         path_transformers,
     }: CreationContext,
-    target_items: Vec<(PathBuf, Option<PathBuf>)>,
+    target_items: Vec<(PathBuf, Option<PathBuf>, bool)>,
 ) -> anyhow::Result<()>
 where
     W: Write,
@@ -415,7 +422,7 @@ fn create_archive_with_split(
         follow_links,
         path_transformers,
     }: CreationContext,
-    target_items: Vec<(PathBuf, Option<PathBuf>)>,
+    target_items: Vec<(PathBuf, Option<PathBuf>, bool)>,
     max_file_size: usize,
     overwrite: bool,
 ) -> anyhow::Result<()> {

--- a/cli/src/command/stdio.rs
+++ b/cli/src/command/stdio.rs
@@ -137,6 +137,12 @@ pub(crate) struct StdioCommand {
     pub(crate) gitignore: bool,
     #[arg(long, visible_aliases = ["dereference"], help = "Follow symbolic links")]
     follow_links: bool,
+    #[arg(
+        short = 'H',
+        long,
+        help = "Follow symbolic links named on the command line"
+    )]
+    follow_command_links: bool,
     #[arg(long, help = "Output directory of extracted files", value_hint = ValueHint::DirPath)]
     pub(crate) out_dir: Option<PathBuf>,
     #[arg(
@@ -296,6 +302,7 @@ fn run_create_archive(args: StdioCommand) -> anyhow::Result<()> {
         args.keep_dir,
         args.gitignore,
         args.follow_links,
+        args.follow_command_links,
         exclude,
     )?;
 
@@ -535,6 +542,7 @@ fn run_append(args: StdioCommand) -> anyhow::Result<()> {
             args.keep_dir,
             args.gitignore,
             args.follow_links,
+            args.follow_command_links,
             exclude,
         )?;
         run_append_archive(&create_options, &path_transformers, archive, target_items)
@@ -545,6 +553,7 @@ fn run_append(args: StdioCommand) -> anyhow::Result<()> {
             args.keep_dir,
             args.gitignore,
             args.follow_links,
+            args.follow_command_links,
             exclude,
         )?;
         let mut output_archive = Archive::write_header(io::stdout().lock())?;

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -224,6 +224,12 @@ pub(crate) struct UpdateCommand {
     pub(crate) gitignore: bool,
     #[arg(long, visible_aliases = ["dereference"], help = "Follow symbolic links")]
     follow_links: bool,
+    #[arg(
+        short = 'H',
+        long,
+        help = "Follow symbolic links named on the command line"
+    )]
+    follow_command_links: bool,
 }
 
 impl Command for UpdateCommand {
@@ -327,6 +333,7 @@ fn update_archive<Strategy: TransformStrategy>(args: UpdateCommand) -> anyhow::R
         args.keep_dir,
         args.gitignore,
         args.follow_links,
+        args.follow_command_links,
         exclude,
     )?;
 
@@ -338,7 +345,7 @@ fn update_archive<Strategy: TransformStrategy>(args: UpdateCommand) -> anyhow::R
 
     let mut target_files_mapping = target_items
         .into_iter()
-        .map(|(it, _)| (EntryName::from_lossy(&it), it))
+        .map(|(it, _, _)| (EntryName::from_lossy(&it), it))
         .collect::<IndexMap<_, _>>();
 
     #[cfg(feature = "memmap")]
@@ -364,7 +371,7 @@ fn update_archive<Strategy: TransformStrategy>(args: UpdateCommand) -> anyhow::R
                         let path_transformers = path_transformers.clone();
                         s.spawn_fifo(move |_| {
                             log::debug!("Updating: {}", target_path.display());
-                            let target_path = (target_path, None);
+                            let target_path = (target_path, None, false);
                             tx.send(create_entry(
                                 &target_path,
                                 &create_options,
@@ -389,7 +396,7 @@ fn update_archive<Strategy: TransformStrategy>(args: UpdateCommand) -> anyhow::R
             let path_transformers = path_transformers.clone();
             s.spawn_fifo(move |_| {
                 log::debug!("Adding: {}", file.display());
-                let file = (file, None);
+                let file = (file, None, false);
                 tx.send(create_entry(&file, &create_options, &path_transformers))
                     .unwrap_or_else(|e| panic!("{e}: {}", file.0.display()));
             });


### PR DESCRIPTION
## Summary
- implement selective symlink following (`-H`) for creation subcommands
- track per-item follow behaviour when collecting files

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --all-features`


------
https://chatgpt.com/codex/tasks/task_b_6884714037688325b93e44a6f1fd52ba