### PR TITLE
Refine partial symlink follow test

### DIFF
--- a/cli/tests/cli/create/symlink.rs
+++ b/cli/tests/cli/create/symlink.rs
@@ -18,6 +18,11 @@ fn init_resource<P: AsRef<Path>>(dir: P) {
 
     fs::create_dir_all(dir.join("dir")).unwrap();
     fs::write(dir.join("dir/in_dir_text.txt"), b"dir_content").unwrap();
+    pna::fs::symlink(
+        Path::new("in_dir_text.txt"),
+        dir.join("dir/in_dir_link.txt"),
+    )
+    .unwrap();
     pna::fs::symlink(Path::new("dir"), dir.join("link_dir")).unwrap();
 }
 
@@ -53,6 +58,9 @@ fn symlink_no_follow() {
             "symlink_no_follow/source/dir/in_dir_text.txt" => {
                 assert_eq!(entry.header().data_kind(), pna::DataKind::File)
             }
+            "symlink_no_follow/source/dir/in_dir_link.txt" => {
+                assert_eq!(entry.header().data_kind(), pna::DataKind::SymbolicLink)
+            }
             "symlink_no_follow/source/link_dir" => {
                 assert_eq!(entry.header().data_kind(), pna::DataKind::SymbolicLink)
             }
@@ -81,6 +89,7 @@ fn symlink_no_follow() {
 
     assert!(PathBuf::from("symlink_no_follow/dist/link.txt").is_symlink());
     assert!(PathBuf::from("symlink_no_follow/dist/link_dir").is_symlink());
+    assert!(PathBuf::from("symlink_no_follow/dist/dir/in_dir_link.txt").is_symlink());
     assert_eq!(
         fs::read_to_string("symlink_no_follow/dist/dir/in_dir_text.txt").unwrap(),
         fs::read_to_string("symlink_no_follow/dist/link_dir/in_dir_text.txt").unwrap(),
@@ -120,8 +129,14 @@ fn symlink_follow() {
             "symlink_follow/source/dir/in_dir_text.txt" => {
                 assert_eq!(entry.header().data_kind(), pna::DataKind::File)
             }
+            "symlink_follow/source/dir/in_dir_link.txt" => {
+                assert_eq!(entry.header().data_kind(), pna::DataKind::File)
+            }
             "symlink_follow/source/link_dir" => {
                 assert_eq!(entry.header().data_kind(), pna::DataKind::Directory)
+            }
+            "symlink_follow/source/link_dir/in_dir_link.txt" => {
+                assert_eq!(entry.header().data_kind(), pna::DataKind::File)
             }
             "symlink_follow/source/link_dir/in_dir_text.txt" => {
                 assert_eq!(entry.header().data_kind(), pna::DataKind::File)
@@ -150,8 +165,63 @@ fn symlink_follow() {
 
     assert!(!PathBuf::from("symlink_follow/dist/link.txt").is_symlink());
     assert!(!PathBuf::from("symlink_follow/dist/link_dir").is_symlink());
+    assert!(!PathBuf::from("symlink_follow/dist/dir/in_dir_link.txt").is_symlink());
+    assert_eq!(
+        fs::read_to_string("symlink_follow/dist/dir/in_dir_link.txt").unwrap(),
+        fs::read_to_string("symlink_follow/dist/dir/in_dir_text.txt").unwrap()
+    );
     assert_eq!(
         fs::read_to_string("symlink_follow/dist/dir/in_dir_text.txt").unwrap(),
         fs::read_to_string("symlink_follow/dist/link_dir/in_dir_text.txt").unwrap(),
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn symlink_follow_command_line_partial() {
+    setup();
+    init_resource("symlink_follow_partial/source");
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "symlink_follow_partial/partial.pna",
+        "--overwrite",
+        "--keep-dir",
+        "-H",
+        "symlink_follow_partial/source",
+        "symlink_follow_partial/source/link.txt",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut link_dir_checked = false;
+    let mut link_txt_checked = false;
+    let mut in_dir_link_checked = false;
+    archive::for_each_entry("symlink_follow_partial/partial.pna", |entry| {
+        match entry.header().path().as_str() {
+            "symlink_follow_partial/source/link_dir" => {
+                link_dir_checked = true;
+                assert_eq!(entry.header().data_kind(), pna::DataKind::SymbolicLink);
+            }
+            "symlink_follow_partial/source/link.txt" => {
+                link_txt_checked = true;
+                assert_eq!(entry.header().data_kind(), pna::DataKind::File);
+            }
+            "symlink_follow_partial/source/dir/in_dir_link.txt" => {
+                in_dir_link_checked = true;
+                assert_eq!(entry.header().data_kind(), pna::DataKind::SymbolicLink);
+            }
+            _ => {}
+        }
+    })
+    .unwrap();
+
+    assert!(link_dir_checked);
+    assert!(link_txt_checked);
+    assert!(in_dir_link_checked);
+
+    // Symlinks inside the directory should remain symbolic links in the archive
+    // when only specific command-line symlinks are followed.
 }


### PR DESCRIPTION
## Summary
- fix assertions in `symlink_follow_command_line_partial` to directly check data kinds

## Testing
- `cargo fmt --all`
- `cargo clippy --locked --all-features`
- `cargo test --locked`


------
https://chatgpt.com/codex/tasks/task_b_6884dfb76fdc83258db67da6fd7eb9be