### PR TITLE
Fix utf8 path normalization for cascading parent dirs

### DIFF
--- a/lib/src/util/utf8path.rs
+++ b/lib/src/util/utf8path.rs
@@ -16,13 +16,17 @@ pub(crate) fn normalize_utf8path(path: impl AsRef<Utf8Path>) -> Utf8PathBuf {
             Utf8Component::Prefix(_) => unreachable!(),
             Utf8Component::RootDir => buf.push(c),
             Utf8Component::CurDir => (),
-            Utf8Component::ParentDir => {
-                if buf.parent().is_some() {
+            Utf8Component::ParentDir => match buf.components().next_back() {
+                Some(Utf8Component::Normal(_)) => {
                     buf.pop();
-                } else {
+                }
+                Some(Utf8Component::ParentDir) | None => buf.push(c),
+                Some(Utf8Component::RootDir | Utf8Component::Prefix(_)) => {}
+                Some(Utf8Component::CurDir) => {
+                    buf.pop();
                     buf.push(c);
                 }
-            }
+            },
             Utf8Component::Normal(_) => buf.push(c),
         }
     }
@@ -41,5 +45,7 @@ mod tests {
         assert_eq!("a.txt", normalize_utf8path("./a.txt"));
         assert_eq!("a.txt", normalize_utf8path("a/../a.txt"));
         assert_eq!("../a.txt", normalize_utf8path("../a.txt"));
+        assert_eq!("../..", normalize_utf8path("../.."));
+        assert_eq!("../../a.txt", normalize_utf8path("../../a.txt"));
     }
 }


### PR DESCRIPTION
## Summary
- adjust `normalize_utf8path` to only pop real path segments so multiple parent-directory components are preserved
- add regression tests covering nested parent-directory normalization cases

## Testing
- cargo fmt
- cargo clippy -p libpna --all-targets
- cargo test -p libpna


------
https://chatgpt.com/codex/tasks/task_b_68d57c52bf20832589a97965da950964