### PR TITLE
Fix include/exclude precedence

### DIFF
--- a/cli/src/command/commons.rs
+++ b/cli/src/command/commons.rs
@@ -1009,7 +1009,15 @@ impl Exclude {
     #[inline]
     pub(crate) fn excluded(&self, s: impl AsRef<str>) -> bool {
         let s = s.as_ref();
-        !self.include.matches_inclusion(s) && self.exclude.matches_exclusion(s)
+        if self.exclude.matches_exclusion(s) {
+            return true;
+        }
+
+        if self.include.is_empty() {
+            return false;
+        }
+
+        !self.include.matches_inclusion(s)
     }
 }
 
@@ -1066,18 +1074,18 @@ mod tests {
     }
 
     #[test]
-    fn exclude_include() {
+    fn exclude_include_precedence() {
         let exclude = Exclude {
             include: vec!["a/*/c"].into(),
             exclude: vec!["a/*"].into(),
         };
-        assert!(!exclude.excluded("a/b/c"));
+        assert!(exclude.excluded("a/b/c"));
 
         let exclude = Exclude {
             include: vec!["a/*/c"].into(),
             exclude: vec!["a/*/c"].into(),
         };
-        assert!(!exclude.excluded("a/b/c"));
+        assert!(exclude.excluded("a/b/c"));
     }
 
     #[test]

--- a/cli/src/utils/globs.rs
+++ b/cli/src/utils/globs.rs
@@ -78,6 +78,11 @@ impl BsdGlobPatterns {
     }
 
     #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    #[inline]
     pub fn matches_exclusion(&self, s: impl AsRef<str>) -> bool {
         self.0.iter().any(|it| it.match_exclusion(s.as_ref()))
     }


### PR DESCRIPTION
## Summary
- ensure `Exclude::excluded` prioritizes matching exclude globs and only uses include patterns when applicable
- add a helper on `BsdGlobPatterns` to detect empty pattern sets and update unit tests for the new precedence behavior

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68dbf5c7ce688325856baa226eba97c1